### PR TITLE
fix typos in FastAPIWrapper

### DIFF
--- a/docs/source/fastapi/index.rst
+++ b/docs/source/fastapi/index.rst
@@ -86,10 +86,10 @@ We also mark one of the endpoints as deprecated.
         piccolo_crud=PiccoloCRUD(
             table=Task,
             read_only=False,
-        )
+        ),
         fastapi_kwargs=FastAPIKwargs(
-            all_endpoints={'tags': ['Task']}  # Added to all endpoints
-            get={'deprecated': True}  # Just added to the 'get' endpoint
+            all_routes={'tags': ['Task']},  # Added to all endpoints
+            get={'deprecated': True},  # Just added to the 'get' endpoint
         )
     )
 


### PR DESCRIPTION
These is just minor documentation fixes to prevent SyntaxError for usage of FastAPIKwargs in FastAPIWrapper.