### PR TITLE
added ids and references endpoints to FastAPIWrapper

### DIFF
--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -205,7 +205,7 @@ class FastAPIWrapper:
 
         async def references(request: Request):
             """
-            Returns the JSON schema for the given table.
+            Returns a list of objects showing relationships with other tables.
             """
             return await piccolo_crud.get_references(request=request)
 

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -64,6 +64,15 @@ class CountModel(BaseModel):
     page_size: int
 
 
+class ReferenceModel(BaseModel):
+    tableName: str
+    columnName: str
+
+
+class ReferencesModel(BaseModel):
+    references: t.List[ReferenceModel]
+
+
 class FastAPIWrapper:
     """
     Wraps ``PiccoloCRUD`` so it can easily be integrated into FastAPI.
@@ -137,6 +146,23 @@ class FastAPIWrapper:
         )
 
         #######################################################################
+        # Root - IDs
+
+        async def ids(request: Request):
+            """
+            Returns a mapping of row IDs to a readable representation.
+            """
+            return await piccolo_crud.get_ids(request=request)
+
+        fastapi_app.add_api_route(
+            path=self.join_urls(root_url, "/ids/"),
+            endpoint=ids,
+            methods=["GET"],
+            response_model=t.Dict[str, str],
+            **fastapi_kwargs.get_kwargs("get"),
+        )
+
+        #######################################################################
         # Root - Count
 
         async def count(request: Request, **kwargs):
@@ -171,6 +197,23 @@ class FastAPIWrapper:
             endpoint=schema,
             methods=["GET"],
             response_model=t.Dict[str, t.Any],
+            **fastapi_kwargs.get_kwargs("get"),
+        )
+
+        #######################################################################
+        # Root - References
+
+        async def references(request: Request):
+            """
+            Returns the JSON schema for the given table.
+            """
+            return await piccolo_crud.get_references(request=request)
+
+        fastapi_app.add_api_route(
+            path=self.join_urls(root_url, "/references/"),
+            endpoint=references,
+            methods=["GET"],
+            response_model=ReferencesModel,
             **fastapi_kwargs.get_kwargs("get"),
         )
 

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from piccolo.engine.sqlite import SQLiteEngine
 from piccolo.table import Table
 from piccolo.columns import Varchar, Integer
+from piccolo.columns.readable import Readable
 from starlette.testclient import TestClient
 
 from piccolo_api.crud.endpoints import PiccoloCRUD
@@ -16,6 +17,10 @@ engine = SQLiteEngine(path="piccolo_api_tests.sqlite")
 class Movie(Table, db=engine):  # type: ignore
     name = Varchar(length=100)
     rating = Integer()
+
+    @classmethod
+    def get_readable(cls) -> Readable:
+        return Readable(template="%s", columns=[cls.name])
 
 
 app = FastAPI()
@@ -100,3 +105,11 @@ class TestResponses(TestCase):
                 },
             },
         )
+
+        response = client.get("/movies/ids/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"1": "Star Wars"})
+
+        response = client.get("/movies/references/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"references": []})


### PR DESCRIPTION
Exposing the `ids` and `references` endpoints in `PiccoloCRUD` in `FastAPIWrapper`.