### PR TITLE
increase compatibility of SessionLoginEndpoint and CSRFMiddleware

### DIFF
--- a/piccolo_api/csrf/middleware.py
+++ b/piccolo_api/csrf/middleware.py
@@ -33,8 +33,10 @@ class CSRFMiddleware(BaseHTTPMiddleware):
     https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
     https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers
 
-    This is currently only intended for use using AJAX - since the CSRF token
-    needs to be added to the request header.
+    By default, the CSRF token needs to be added to the request header. By
+    setting `allow_form_param` to True, it will also work if added as a form
+    parameter.
+
     """
 
     @staticmethod
@@ -87,12 +89,19 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             if token_required:
                 token = self.get_new_token()
 
-            request.scope.update({"csrftoken": token})
+            request.scope.update(
+                {
+                    "csrftoken": token,
+                    "csrf_cookie_name": self.cookie_name,
+                }
+            )
             response = await call_next(request)
 
             if token_required and token:
                 response.set_cookie(
-                    self.cookie_name, token, max_age=self.max_age,
+                    self.cookie_name,
+                    token,
+                    max_age=self.max_age,
                 )
             return response
         else:

--- a/piccolo_api/session_auth/templates/login.html
+++ b/piccolo_api/session_auth/templates/login.html
@@ -37,6 +37,10 @@
         <label>Password</label>
         <input type="password" name="password" />
 
+        {% if csrftoken and csrf_cookie_name %}
+            <input type="hidden" name="{{ csrf_cookie_name }}" value="{{ csrftoken }}" />
+        {% endif %}
+
         <input type="submit" />
     </form>
 </body>


### PR DESCRIPTION
If using CSRFMiddleware and embedding the token within a form field, it is now compatible with SessionLoginEndpoint