### PR TITLE
making fastapi non optional - trying to get around the starlette clash

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r tests/test-requirements.txt
-          pip install fastapi
       - name: Test with pytest
         run: cd tests && ./run-tests.sh && cd ..

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -12,14 +12,8 @@ import typing as t
 
 from pydantic.main import BaseModel
 
-try:
-    from fastapi import FastAPI, Request
-    from fastapi.params import Query
-except ImportError:
-    print(
-        "Install fastapi to use this feature - "
-        "pip install piccolo_api[fastapi]."
-    )
+from fastapi import FastAPI, Request
+from fastapi.params import Query
 from pydantic import BaseModel as PydanticBaseModel
 
 from piccolo_api.crud.endpoints import PiccoloCRUD

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Jinja2>=2.11.0
 piccolo>=0.14.10
 pydantic>=1.6
 python-multipart>=0.0.5
-starlette>=0.13.0
+fastapi>=0.58.0
 PyJWT>=1.7.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     url="https://github.com/piccolo-orm/piccolo_api",
     packages=find_packages(exclude=("tests",)),
     install_requires=REQUIREMENTS,
-    extras_require={"fastapi": ["fastapi>=0.58.0"]},
     license="MIT",
     classifiers=[
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Starlette 0.14.2 is incompatible with FastAPI, and pip isn't very smart in resolving the dependency versions without breaking.