### PR TITLE
the get_ids endpoint can now be filtered using the search parameter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo>=0.14.10
+piccolo>=0.16.3
 pydantic>=1.6
 python-multipart>=0.0.5
 fastapi>=0.58.0

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -154,13 +154,14 @@ class TestIDs(TestCase):
         movie_2 = Movie(name="Lord of the Rings", rating=90)
         movie_2.save().run_sync()
 
-        response = client.get("/ids/?search=star")
-        self.assertTrue(response.status_code == 200)
+        for search_term in ('star', 'Star', "Star Wars", 'STAR WARS'):
+            response = client.get(f"/ids/?search={search_term}")
+            self.assertTrue(response.status_code == 200)
 
-        # Make sure the content is correct:
-        response_json = response.json()
-        self.assertEqual(len(response_json), 1)
-        self.assertTrue("Star Wars" in response_json.values())
+            # Make sure the content is correct:
+            response_json = response.json()
+            self.assertEqual(len(response_json), 1)
+            self.assertTrue("Star Wars" in response_json.values())
 
 
 class TestCount(TestCase):

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -142,6 +142,26 @@ class TestIDs(TestCase):
         response_json = response.json()
         self.assertEqual(response_json[str(movie.id)], "Star Wars")
 
+    def test_get_ids_with_search(self):
+        """
+        Try the search parameter.
+        """
+        client = TestClient(PiccoloCRUD(table=Movie, read_only=False))
+
+        movie_1 = Movie(name="Star Wars", rating=93)
+        movie_1.save().run_sync()
+
+        movie_2 = Movie(name="Lord of the Rings", rating=90)
+        movie_2.save().run_sync()
+
+        response = client.get("/ids/?search=star")
+        self.assertTrue(response.status_code == 200)
+
+        # Make sure the content is correct:
+        response_json = response.json()
+        self.assertEqual(len(response_json), 1)
+        self.assertTrue("Star Wars" in response_json.values())
+
 
 class TestCount(TestCase):
     def setUp(self):


### PR DESCRIPTION
The `get_ids` endpoint of `PiccoloCRUD`, accessed via `/tablename/ids/`, now accepts a search parameter.