### PR TITLE
using constrained types for pydantic

### DIFF
--- a/piccolo_api/crud/serializers.py
+++ b/piccolo_api/crud/serializers.py
@@ -64,7 +64,7 @@ def create_pydantic_model(
 
         if isinstance(column, (Decimal, Numeric)):
             value_type: t.Type = pydantic.condecimal(
-                decimal_places=column.scale
+                max_digits=column.precision, decimal_places=column.scale
             )
         elif isinstance(column, Varchar):
             value_type = pydantic.constr(max_length=column.length)

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -154,7 +154,7 @@ class TestIDs(TestCase):
         movie_2 = Movie(name="Lord of the Rings", rating=90)
         movie_2.save().run_sync()
 
-        for search_term in ('star', 'Star', "Star Wars", 'STAR WARS'):
+        for search_term in ("star", "Star", "Star Wars", "STAR WARS"):
             response = client.get(f"/ids/?search={search_term}")
             self.assertTrue(response.status_code == 200)
 
@@ -254,6 +254,7 @@ class TestSchema(TestCase):
                 "properties": {
                     "name": {
                         "title": "Name",
+                        "maxLength": 100,
                         "extra": {},
                         "nullable": False,
                         "type": "string",

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from piccolo.table import Table
+from piccolo.columns import Varchar
+from pydantic import ValidationError
+
+from piccolo_api.crud.serializers import create_pydantic_model
+
+
+class TestVarchar(TestCase):
+    def test_varchar_length(self):
+        class Director(Table):
+            name = Varchar(length=10)
+
+        pydantic_model = create_pydantic_model(table=Director)
+
+        with self.assertRaises(ValidationError):
+            pydantic_model(name="This is a really long name")
+
+        pydantic_model(name="short name")

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -1,7 +1,8 @@
+import decimal
 from unittest import TestCase
 
 from piccolo.table import Table
-from piccolo.columns import Varchar
+from piccolo.columns import Varchar, Numeric
 from pydantic import ValidationError
 
 from piccolo_api.crud.serializers import create_pydantic_model
@@ -18,3 +19,20 @@ class TestVarchar(TestCase):
             pydantic_model(name="This is a really long name")
 
         pydantic_model(name="short name")
+
+
+class TestNumeric(TestCase):
+    """
+    Numeric and Decimal are the same - so we'll just Numeric.
+    """
+
+    def test_numeric_length(self):
+        class Movie(Table):
+            box_office = Numeric(digits=(5, 1))
+
+        pydantic_model = create_pydantic_model(table=Movie)
+
+        with self.assertRaises(ValidationError):
+            pydantic_model(box_office=decimal.Decimal("1.11111111"))
+
+        pydantic_model(box_office=decimal.Decimal("1.0"))

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -26,13 +26,19 @@ class TestNumeric(TestCase):
     Numeric and Decimal are the same - so we'll just Numeric.
     """
 
-    def test_numeric_length(self):
+    def test_numeric_digits(self):
         class Movie(Table):
             box_office = Numeric(digits=(5, 1))
 
         pydantic_model = create_pydantic_model(table=Movie)
 
         with self.assertRaises(ValidationError):
-            pydantic_model(box_office=decimal.Decimal("1.11111111"))
+            # This should fail as there are too much numbers after the decimal
+            # point
+            pydantic_model(box_office=decimal.Decimal("1.11"))
+
+        with self.assertRaises(ValidationError):
+            # This should fail as there are too much numbers in total
+            pydantic_model(box_office=decimal.Decimal("11111.1"))
 
         pydantic_model(box_office=decimal.Decimal("1.0"))

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -93,6 +93,7 @@ class TestResponses(TestCase):
                     "name": {
                         "title": "Name",
                         "extra": {},
+                        "maxLength": 100,
                         "nullable": False,
                         "type": "string",
                     },


### PR DESCRIPTION
Pydantic can be given constrained types. For example `constr` instead of `str`. Pydantic will then do extra validation.

https://pydantic-docs.helpmanual.io/usage/types/#constrained-types

Good examples of how this is useful in Piccolo is having the length limit of `Varchar` enforced by Pydantic.



