### PR TITLE
PiccoloCRUD.get_ids accepts a limit parameter

### DIFF
--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -144,15 +144,14 @@ class TestIDs(TestCase):
 
     def test_get_ids_with_search(self):
         """
-        Try the search parameter.
+        Test the search parameter.
         """
         client = TestClient(PiccoloCRUD(table=Movie, read_only=False))
 
-        movie_1 = Movie(name="Star Wars", rating=93)
-        movie_1.save().run_sync()
-
-        movie_2 = Movie(name="Lord of the Rings", rating=90)
-        movie_2.save().run_sync()
+        Movie.insert(
+            Movie(name="Star Wars", rating=93),
+            Movie(name="Lord of the Rings", rating=90),
+        ).run_sync()
 
         for search_term in ("star", "Star", "Star Wars", "STAR WARS"):
             response = client.get(f"/ids/?search={search_term}")
@@ -162,6 +161,26 @@ class TestIDs(TestCase):
             response_json = response.json()
             self.assertEqual(len(response_json), 1)
             self.assertTrue("Star Wars" in response_json.values())
+
+    def test_get_ids_with_limit(self):
+        """
+        Test the limit parameter.
+        """
+        client = TestClient(PiccoloCRUD(table=Movie, read_only=False))
+
+        Movie.insert(
+            Movie(name="Star Wars", rating=93),
+            Movie(name="Lord of the Rings", rating=90),
+        ).run_sync()
+
+        response = client.get(f"/ids/?limit=1")
+        self.assertTrue(response.status_code == 200)
+        response_json = response.json()
+        self.assertEqual(len(response_json), 1)
+
+        # Make sure only valid limit values are accepted.
+        response = client.get(f"/ids/?limit=abc")
+        self.assertEqual(response.status_code, 400)
 
 
 class TestCount(TestCase):


### PR DESCRIPTION
The ids endpoint now accepts a limit parameter - needed for Piccolo Admin's foreign key selector.