### PR TITLE
add Column help text to the Pydantic schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo>=0.16.3
+piccolo>=0.17.3
 pydantic>=1.6
 python-multipart>=0.0.5
 fastapi>=0.58.0

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -270,13 +270,13 @@ class TestSchema(TestCase):
                     "name": {
                         "title": "Name",
                         "maxLength": 100,
-                        "extra": {},
+                        "extra": {"help_text": None},
                         "nullable": False,
                         "type": "string",
                     },
                     "rating": {
                         "title": "Rating",
-                        "extra": {},
+                        "extra": {"help_text": None},
                         "nullable": False,
                         "type": "integer",
                     },

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -42,3 +42,25 @@ class TestNumeric(TestCase):
             pydantic_model(box_office=decimal.Decimal("11111.1"))
 
         pydantic_model(box_office=decimal.Decimal("1.0"))
+
+
+class TestHelpText(TestCase):
+    """
+    Make sure that columns with `help_text` attribute defined have the
+    relevant text appear in the schema.
+    """
+
+    def test_help_text_present(self):
+
+        help_text = "In millions of US dollars."
+
+        class Movie(Table):
+            box_office = Numeric(digits=(5, 1), help_text=help_text)
+
+        pydantic_model = create_pydantic_model(table=Movie)
+        self.assertEqual(
+            pydantic_model.schema()["properties"]["box_office"]["extra"][
+                "help_text"
+            ],
+            help_text,
+        )

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -88,14 +88,14 @@ class TestResponses(TestCase):
                 "properties": {
                     "name": {
                         "title": "Name",
-                        "extra": {},
+                        "extra": {"help_text": None},
                         "maxLength": 100,
                         "nullable": False,
                         "type": "string",
                     },
                     "rating": {
                         "title": "Rating",
-                        "extra": {},
+                        "extra": {"help_text": None},
                         "nullable": False,
                         "type": "integer",
                     },


### PR DESCRIPTION
In order to expose the `help_text` attribute of `Column`, the Pydantic schema needed modifying.