### PR TITLE
add Table help text to serialiser

### DIFF
--- a/piccolo_api/crud/serializers.py
+++ b/piccolo_api/crud/serializers.py
@@ -105,4 +105,9 @@ def create_pydantic_model(
 
     model_name = model_name if model_name else table.__name__
 
-    return pydantic.create_model(model_name, __config__=Config, **columns)
+    class CustomConfig(Config):
+        schema_extra = {"help_text": table._meta.help_text}
+
+    return pydantic.create_model(
+        model_name, __config__=CustomConfig, **columns
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo>=0.17.3
+piccolo>=0.17.4
 pydantic>=1.6
 python-multipart>=0.0.5
 fastapi>=0.58.0

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -282,6 +282,7 @@ class TestSchema(TestCase):
                     },
                 },
                 "required": ["name"],
+                "help_text": None,
             },
         )
 

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -44,7 +44,7 @@ class TestNumeric(TestCase):
         pydantic_model(box_office=decimal.Decimal("1.0"))
 
 
-class TestHelpText(TestCase):
+class TestColumnHelpText(TestCase):
     """
     Make sure that columns with `help_text` attribute defined have the
     relevant text appear in the schema.
@@ -62,5 +62,25 @@ class TestHelpText(TestCase):
             pydantic_model.schema()["properties"]["box_office"]["extra"][
                 "help_text"
             ],
+            help_text,
+        )
+
+
+class TestTableHelpText(TestCase):
+    """
+    Make sure that tables with `help_text` attribute defined have the
+    relevant text appear in the schema.
+    """
+
+    def test_help_text_present(self):
+
+        help_text = "Movies which were released in cinemas."
+
+        class Movie(Table, help_text=help_text):
+            name = Varchar()
+
+        pydantic_model = create_pydantic_model(table=Movie)
+        self.assertEqual(
+            pydantic_model.schema()["help_text"],
             help_text,
         )

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -100,6 +100,7 @@ class TestResponses(TestCase):
                         "type": "integer",
                     },
                 },
+                "help_text": None,
             },
         )
 


### PR DESCRIPTION
If the `help_text` parameter is specified for a `Table`, add it to the Pydantic serialiser.