### PR TITLE
Cursor pagination improvements

### DIFF
--- a/piccolo_api/crud/serializers.py
+++ b/piccolo_api/crud/serializers.py
@@ -20,6 +20,11 @@ class Config(pydantic.BaseConfig):
     arbitrary_types_allowed = True
 
 
+# cursor model
+class Cursor(pydantic.BaseModel):
+    next_cursor: str
+
+
 @lru_cache()
 def create_pydantic_model(
     table: t.Type[Table],
@@ -87,9 +92,7 @@ def create_pydantic_model(
         extra = {"help_text": column._meta.help_text}
 
         if isinstance(column, ForeignKey):
-            tablename = (
-                column._foreign_key_meta.resolved_references._meta.tablename
-            )
+            tablename = column._foreign_key_meta.resolved_references._meta.tablename
             field = pydantic.Field(
                 extra={"foreign_key": True, "to": tablename, **extra},
                 **params,
@@ -108,6 +111,4 @@ def create_pydantic_model(
     class CustomConfig(Config):
         schema_extra = {"help_text": table._meta.help_text}
 
-    return pydantic.create_model(
-        model_name, __config__=CustomConfig, **columns
-    )
+    return pydantic.create_model(model_name, __config__=CustomConfig, **columns)

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -490,6 +490,26 @@ class FastAPIWrapper:
                                 ),
                             ),
                         ),
+                        Parameter(
+                            name="__cursor",
+                            kind=Parameter.POSITIONAL_OR_KEYWORD,
+                            annotation=str,
+                            default=Query(
+                                default=None,
+                                description=("Cursor based pagination."),
+                            ),
+                        ),
+                        Parameter(
+                            name="__previous",
+                            kind=Parameter.POSITIONAL_OR_KEYWORD,
+                            annotation=str,
+                            default=Query(
+                                default=None,
+                                description=(
+                                    "Set yes to get previous page from next_cursor."
+                                ),
+                            ),
+                        ),
                     ]
                 )
 


### PR DESCRIPTION
Added the ability to move in different directions (forward and backward) from next_cursor. 

```
Example:
http://localhost:8000/posts/?__page_size=3&__order=id&__cursor=NA== (ASC forward)
http://localhost:8000/posts/?__page_size=3&__order=id&__cursor=NA==&__previous=yes (ASC backward)
http://localhost:8000/posts/?__page_size=3&__order=-id&__cursor=OQ== (DESC forward)
http://localhost:8000/posts/?__page_size=3&__order=-id&__cursor=OQ==&__previous=yes (DESC backward)
```

This is quite tricky with a lot of edge cases. I don't know exactly how to use cursor pagination in piccolo_admin. LimitOffset pagination works good (up to 200,000 rows), and is quite convinient.
We may use cursor pagination above that number (maybe millions of rows, but I’m have never encountered such large data sets), but then we lose the ability to sort by all columns except by id, because the cursor must be unique. 
You probably know much better than I how to implement that. Cheers.