### PR TITLE
Extra session auth options

### DIFF
--- a/docs/source/session_auth/index.rst
+++ b/docs/source/session_auth/index.rst
@@ -18,14 +18,16 @@ There are several advantages to session auth:
  * A session can be invalidated at any time, by deleting a session from the database.
  * HTTP-only cookies are immune to tampering with Javascript.
 
+-------------------------------------------------------------------------------
+
 Tables
 ------
 
 You need somewhere to store session tokens, and also somewhere to store user
 credentials.
 
-You can add `piccolo_api.session_auth.piccolo_app` to the `apps` arguments of
-the `AppRegistry` in `piccolo_conf.py`.
+You can add ``piccolo_api.session_auth.piccolo_app`` to the ``apps`` arguments
+of the ``AppRegistry`` in ``piccolo_conf.py``.
 
 .. code-block:: bash
 
@@ -47,6 +49,8 @@ To run the migrations and create the tables, run:
     piccolo migrations forwards session_auth
 
 You can also choose to manually create the tables if you prefer.
+
+-------------------------------------------------------------------------------
 
 Endpoints
 ---------
@@ -82,10 +86,12 @@ This unsets the cookie value, and invalidates the session in the database.
 
     logout_endpoint = session_logout()
 
+-------------------------------------------------------------------------------
+
 Middleware
 ----------
 
-You can protect any endpoints using the `SessionsAuthBackend`.
+You can protect any endpoints using the ``SessionsAuthBackend``.
 
 .. code-block:: python
 
@@ -98,3 +104,7 @@ You can protect any endpoints using the `SessionsAuthBackend`.
         my_asgi_app,
         backend=SessionsAuthBackend(),
     )
+
+.. currentmodule:: piccolo_api.session_auth.middleware
+
+.. autoclass:: SessionsAuthBackend

--- a/piccolo_api/session_auth/middleware.py
+++ b/piccolo_api/session_auth/middleware.py
@@ -27,6 +27,8 @@ class SessionsAuthBackend(AuthenticationBackend):
         session_table: t.Type[SessionsBase] = SessionsBase,
         cookie_name: str = "id",
         admin_only: bool = True,
+        superuser_only: bool = False,
+        active_only: bool = True,
         increase_expiry: t.Optional[timedelta] = None,
     ):
         """
@@ -40,6 +42,8 @@ class SessionsAuthBackend(AuthenticationBackend):
         self.session_table = session_table
         self.cookie_name = cookie_name
         self.admin_only = admin_only
+        self.superuser_only = superuser_only
+        self.active_only = active_only
         self.increase_expiry = increase_expiry
 
     async def authenticate(
@@ -68,6 +72,12 @@ class SessionsAuthBackend(AuthenticationBackend):
 
         if self.admin_only and not piccolo_user.admin:
             raise AuthenticationError("Admin users only")
+
+        if self.superuser_only and not piccolo_user.superuser:
+            raise AuthenticationError("Superusers only")
+
+        if self.active_only and not piccolo_user.active:
+            raise AuthenticationError("Active users only")
 
         user = User(
             auth_table=self.auth_table,

--- a/piccolo_api/session_auth/middleware.py
+++ b/piccolo_api/session_auth/middleware.py
@@ -32,6 +32,19 @@ class SessionsAuthBackend(AuthenticationBackend):
         increase_expiry: t.Optional[timedelta] = None,
     ):
         """
+        :param auth_table:
+            The Piccolo table used for authenticating users.
+        :param session_table:
+            The Piccolo table used for storing sessions.
+        :param cookie_name:
+            The name of the session cookie. Override this if it clashes with
+            other cookies in your application.
+        :param admin_only:
+            If True, users which aren't admins will be rejected.
+        :param superuser_only:
+            If True, users which aren't superusers will be rejected.
+        :param active_only:
+            If True, users which aren't active will be rejected.
         :param increase_expiry:
             If set, the session expiry will be increased by this amount on each
             request, if it's close to expiry. This allows sessions to have a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo>=0.18.2
+piccolo>=0.19.0
 pydantic>=1.6
 python-multipart>=0.0.5
 fastapi>=0.58.0

--- a/tests/session_auth/test_session.py
+++ b/tests/session_auth/test_session.py
@@ -38,10 +38,12 @@ ROUTER = Router(
         ),
         Route("/logout/", session_logout(), name="login"),
         Mount(
-            "/secret",
+            "/secret/",
             AuthenticationMiddleware(
                 ProtectedEndpoint,
-                SessionsAuthBackend(),
+                SessionsAuthBackend(
+                    admin_only=True, superuser_only=True, active_only=True
+                ),
             ),
         ),
     ]
@@ -66,17 +68,106 @@ class TestSessions(TestCase):
         BaseUser.alter().drop_table().run_sync()
 
     def test_create_session(self):
+        """
+        Make sure sessions can be stored in the database.
+        """
         SessionsBase.create_session_sync(user_id=1)
+        self.assertEqual(
+            SessionsBase.select("user_id").run_sync(), [{"user_id": 1}]
+        )
 
-    def test_login_failure(self):
+    def test_wrong_credentials(self):
+        """
+        Make sure a user can't login using wrong credentials.
+        """
         client = TestClient(APP)
+        BaseUser(
+            **self.credentials, active=True, admin=True, superuser=True
+        ).save().run_sync()
+
+        # Test with the wrong username and password.
         response = client.post("/login/", json=self.wrong_credentials)
         self.assertTrue(response.status_code == 401)
         self.assertTrue(response.cookies.values() == [])
 
+        # Test with the correct username, but wrong password.
+        response = client.post(
+            "/login/",
+            json={
+                "username": self.credentials["username"],
+                "password": self.wrong_credentials["password"],
+            },
+        )
+        self.assertTrue(response.status_code == 401)
+        self.assertTrue(response.cookies.values() == [])
+
     def test_login_success(self):
+        """
+        Make sure a user with the correct permissions can access the protected
+        endpoint.
+        """
         client = TestClient(APP)
-        BaseUser(**self.credentials).save().run_sync()
+        BaseUser(
+            **self.credentials, active=True, admin=True, superuser=True
+        ).save().run_sync()
         response = client.post("/login/", json=self.credentials)
         self.assertTrue(response.status_code == 303)
         self.assertTrue("id" in response.cookies.keys())
+
+        response = client.get("/secret/")
+        self.assertTrue(response.status_code == 200)
+        self.assertEqual(response.content, b"top secret")
+
+    def test_inactive_user(self):
+        """
+        Inactive users should be rejected by the middleware, if configured
+        that way.
+        """
+        client = TestClient(APP)
+        BaseUser(
+            **self.credentials, active=False, admin=True, superuser=True
+        ).save().run_sync()
+        response = client.post("/login/", json=self.credentials)
+
+        # Currently the login is successful if the user is inactive - this
+        # should change in the future.
+        self.assertTrue(response.status_code == 303)
+
+        # Make a request using the session - it should get rejected.
+        response = client.get("/secret/")
+        self.assertTrue(response.status_code == 400)
+        self.assertEqual(response.content, b"Active users only")
+
+    def test_non_superuser(self):
+        """
+        Non-superusers should by rejected by the middleware, if configured
+        that way.
+        """
+        client = TestClient(APP)
+        BaseUser(
+            **self.credentials, active=True, admin=True, superuser=False
+        ).save().run_sync()
+        response = client.post("/login/", json=self.credentials)
+        self.assertTrue(response.status_code == 303)
+
+        # Make a request using the session - it should get rejected.
+        response = client.get("/secret/")
+        self.assertTrue(response.status_code == 400)
+        self.assertEqual(response.content, b"Superusers only")
+
+    def test_non_admin(self):
+        """
+        Non-admin users should be rejected by the middleware, if configured
+        that way.
+        """
+        client = TestClient(APP)
+        BaseUser(
+            **self.credentials, active=True, admin=False, superuser=False
+        ).save().run_sync()
+        response = client.post("/login/", json=self.credentials)
+        self.assertTrue(response.status_code == 303)
+
+        # Make a request using the session - it should get rejected.
+        response = client.get("/secret/")
+        self.assertTrue(response.status_code == 400)
+        self.assertEqual(response.content, b"Admin users only")


### PR DESCRIPTION
``SessionsAuthBackend`` can now be configured to reject users which aren't active, or aren't superusers.