### PR TITLE
Secret column improvements

### DIFF
--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -87,6 +87,7 @@ class PiccoloCRUD(Router):
         read_only: bool = True,
         allow_bulk_delete: bool = False,
         page_size: int = 15,
+        exclude_secrets: bool = True,
     ) -> None:
         """
         :param table:
@@ -98,11 +99,14 @@ class PiccoloCRUD(Router):
             records. It is dangerous, so is disabled by default.
         :param page_size:
             The number of results shown on each page by default.
+        :param exclude_secrets:
+            Any values in Secret columns will be omitted from the response.
         """
         self.table = table
         self.page_size = page_size
         self.read_only = read_only
         self.allow_bulk_delete = allow_bulk_delete
+        self.exclude_secrets = exclude_secrets
 
         root_methods = ["GET"]
         if not read_only:
@@ -262,11 +266,7 @@ class PiccoloCRUD(Router):
                 if isinstance(limit, int):
                     sql += f" LIMIT {limit}"
                 query = t.cast(
-                    Select,
-                    self.table.raw(
-                        sql,
-                        f"%{search_term.upper()}%",
-                    ),
+                    Select, self.table.raw(sql, f"%{search_term.upper()}%",),
                 )
         else:
             if limit != "ALL":
@@ -458,10 +458,7 @@ class PiccoloCRUD(Router):
                 values = value if isinstance(value, list) else [value]
 
                 for value in values:
-                    if isinstance(
-                        column,
-                        (Varchar, Text),
-                    ):
+                    if isinstance(column, (Varchar, Text),):
                         match_type = params.match_types[field_name]
                         if match_type == "exact":
                             clause = column.__eq__(value)
@@ -500,9 +497,11 @@ class PiccoloCRUD(Router):
                 for i in self.table._meta.foreign_key_columns
             ]
             columns = self.table._meta.columns + readable_columns
-            query = self.table.select(*columns)
+            query = self.table.select(
+                *columns, exclude_secrets=self.exclude_secrets
+            )
         else:
-            query = self.table.select()
+            query = self.table.select(exclude_secrets=self.exclude_secrets)
 
         # Apply filters
         try:
@@ -523,9 +522,7 @@ class PiccoloCRUD(Router):
         # If the page_size is greater than max_page_size return an error
         if page_size > self.max_page_size:
             return JSONResponse(
-                {
-                    "error": "The page size limit has been exceeded",
-                },
+                {"error": "The page size limit has been exceeded"},
                 status_code=403,
             )
         query = query.limit(page_size)
@@ -656,7 +653,9 @@ class PiccoloCRUD(Router):
                 columns = columns + readable_columns
 
             row = (
-                await self.table.select(*columns)
+                await self.table.select(
+                    *columns, exclude_secrets=self.exclude_secrets
+                )
                 .where(self.table.id == row_id)
                 .first()
                 .run()

--- a/piccolo_api/crud/serializers.py
+++ b/piccolo_api/crud/serializers.py
@@ -11,6 +11,7 @@ from piccolo.columns.column_types import (
     Decimal,
     Numeric,
     Varchar,
+    Secret,
 )
 from piccolo.table import Table
 import pydantic
@@ -101,6 +102,8 @@ def create_pydantic_model(
                 columns[f"{column_name}_readable"] = (str, None)
         elif isinstance(column, Text):
             field = pydantic.Field(format="text-area", extra=extra, **params)
+        elif isinstance(column, Secret):
+            field = pydantic.Field(extra={"secret": True, **extra})
         else:
             field = pydantic.Field(extra=extra, **params)
 

--- a/tests/crud/test_serializers.py
+++ b/tests/crud/test_serializers.py
@@ -1,5 +1,6 @@
 import decimal
 from unittest import TestCase
+from piccolo.columns.column_types import Secret
 
 from piccolo.table import Table
 from piccolo.columns import Varchar, Numeric
@@ -8,7 +9,7 @@ from pydantic import ValidationError
 from piccolo_api.crud.serializers import create_pydantic_model
 
 
-class TestVarchar(TestCase):
+class TestVarcharColumn(TestCase):
     def test_varchar_length(self):
         class Director(Table):
             name = Varchar(length=10)
@@ -21,7 +22,7 @@ class TestVarchar(TestCase):
         pydantic_model(name="short name")
 
 
-class TestNumeric(TestCase):
+class TestNumericColumn(TestCase):
     """
     Numeric and Decimal are the same - so we'll just Numeric.
     """
@@ -42,6 +43,20 @@ class TestNumeric(TestCase):
             pydantic_model(box_office=decimal.Decimal("11111.1"))
 
         pydantic_model(box_office=decimal.Decimal("1.0"))
+
+
+class TestSecretColumn(TestCase):
+    def test_secret_param(self):
+        class TopSecret(Table):
+            confidential = Secret()
+
+        pydantic_model = create_pydantic_model(table=TopSecret)
+        self.assertEqual(
+            pydantic_model.schema()["properties"]["confidential"]["extra"][
+                "secret"
+            ],
+            True,
+        )
 
 
 class TestColumnHelpText(TestCase):


### PR DESCRIPTION
`PiccoloCRUD` can now be configured to automatically remove values for `Secret` columns in responses.

The Pydantic serialiser now also shows if columns are `Secret` in the schema.