### PR TITLE
refactor the Starlette `BaseUser` subclass to store the Piccolo `BaseUser` instance

### DIFF
--- a/piccolo_api/jwt_auth/middleware.py
+++ b/piccolo_api/jwt_auth/middleware.py
@@ -20,7 +20,7 @@ class JWTMiddleware:
     Protects an endpoint - only allows access if a JWT token is presented.
     """
 
-    auth_table: BaseUser = None
+    auth_table: t.Optional[t.Type[BaseUser]] = None
 
     def __init__(
         self,
@@ -55,6 +55,9 @@ class JWTMiddleware:
         user_id = token_dict.get("user_id", None)
 
         if not user_id:
+            return None
+
+        if not self.auth_table:
             return None
 
         exists = (

--- a/piccolo_api/session_auth/middleware.py
+++ b/piccolo_api/session_auth/middleware.py
@@ -92,10 +92,6 @@ class SessionsAuthBackend(AuthenticationBackend):
         if self.active_only and not piccolo_user.active:
             raise AuthenticationError("Active users only")
 
-        user = User(
-            auth_table=self.auth_table,
-            user_id=piccolo_user.id,
-            username=piccolo_user.username,
-        )
+        user = User(user=piccolo_user)
 
         return (AuthCredentials(scopes=["authenticated"]), user)

--- a/piccolo_api/shared/auth/user.py
+++ b/piccolo_api/shared/auth/user.py
@@ -4,15 +4,33 @@ import typing as t
 from piccolo.apps.user.tables import BaseUser as PiccoloBaseUser
 from starlette.authentication import BaseUser
 
+if t.TYPE_CHECKING:
+    from piccolo.table import Table
+
 
 class User(BaseUser):
-    def __init__(
-        self, auth_table: t.Type[PiccoloBaseUser], user_id: int, username: str
-    ):
+    def __init__(self, user: PiccoloBaseUser):
         super().__init__()
-        self.auth_table = auth_table
-        self.user_id = user_id
-        self.username = username
+        self.user = user
+
+    ###########################################################################
+    # For backwards compatibility - these used to be arguments to the
+    # contructor, but we can just infer them from the user instance.
+
+    @property
+    def auth_table(self) -> t.Type[Table]:
+        return self.user.__class__
+
+    @property
+    def user_id(self) -> int:
+        return t.cast(int, self.user.id)
+
+    @property
+    def username(self) -> str:
+        return t.cast(str, self.user.username)
+
+    ###########################################################################
+    # Required properties.
 
     @property
     def is_authenticated(self) -> bool:

--- a/piccolo_api/token_auth/middleware.py
+++ b/piccolo_api/token_auth/middleware.py
@@ -63,16 +63,17 @@ class PiccoloTokenAuthProvider(TokenAuthProvider):
         if not user_id:
             raise AuthenticationError()
 
-        username = (
+        user = (
             await self.auth_table.select(self.auth_table.username)
             .where(self.auth_table.id == user_id)
             .first()
             .run()
-        )["username"]
-
-        user = User(
-            auth_table=self.auth_table, user_id=user_id, username=username
         )
+
+        if not user:
+            raise AuthenticationError()
+
+        user = User(user=user)
         return user
 
 


### PR DESCRIPTION
The authentication middleware is based off Starlette's middleware.

If authentication is successful then the Starlette middleware injects Starlette's [User](https://www.starlette.io/authentication.html#users) instance into the request scope.

Previously, the Piccolo User instance wasn't stored on the Starlette User instance (only the ID), which meant that any endpoints would have to re-fetch the Piccolo user from the database, which was wasteful.