### PR TITLE
add oauth redirect endpoint

### DIFF
--- a/piccolo_api/openapi/templates/swagger_ui.html.jinja
+++ b/piccolo_api/openapi/templates/swagger_ui.html.jinja
@@ -15,9 +15,12 @@
     {% endif %}
 
     <script>
+        const rootURL = window.location.origin + window.location.pathname;
+        const oauth2RedirectUrl = rootURL.endsWith('/') ? rootURL + 'oauth2-redirect/' : rootURL + '/oauth2-redirect/';
+
         const ui = SwaggerUIBundle({
             url: '{{ schema_url }}',
-            oauth2RedirectUrl: window.location.origin + '{{ schema_url }}',
+            oauth2RedirectUrl: oauth2RedirectUrl,
             dom_id: '#swagger-ui',
             presets: [
                 SwaggerUIBundle.presets.apis,

--- a/tests/openapi/test_openapi_endpoints.py
+++ b/tests/openapi/test_openapi_endpoints.py
@@ -11,10 +11,13 @@ class TestSwaggerUI(TestCase):
         Make sure swagger_ui can be mounted within a FastAPI app.
         """
         app = FastAPI(docs_url=None, redoc_url=None)
-        app.add_route("/docs/", swagger_ui())
+        app.mount("/docs/", swagger_ui())
 
         client = TestClient(app)
-        response = client.get("/docs/")
 
+        response = client.get("/docs/")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.content.find(b"Piccolo Swagger UI") != -1)
+
+        response = client.get("/docs/oauth2-redirect/")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Slight refactor of `swagger_ui`, to include the oauth redirect HTML.