### PR TITLE
Custom title for Swagger UI

### DIFF
--- a/piccolo_api/openapi/endpoints.py
+++ b/piccolo_api/openapi/endpoints.py
@@ -23,6 +23,7 @@ ENVIRONMENT = jinja2.Environment(
 
 def swagger_ui(
     schema_url: str = "/openapi.json",
+	swagger_ui_title: str = "Piccolo Swagger UI",
     csrf_cookie_name: t.Optional[str] = DEFAULT_COOKIE_NAME,
     csrf_header_name: t.Optional[str] = DEFAULT_HEADER_NAME,
 ):
@@ -64,6 +65,7 @@ def swagger_ui(
             template = ENVIRONMENT.get_template("swagger_ui.html.jinja")
             html = template.render(
                 schema_url=schema_url,
+				swagger_ui_title=swagger_ui_title,
                 csrf_cookie_name=csrf_cookie_name,
                 csrf_header_name=csrf_header_name,
             )

--- a/piccolo_api/openapi/endpoints.py
+++ b/piccolo_api/openapi/endpoints.py
@@ -23,7 +23,7 @@ ENVIRONMENT = jinja2.Environment(
 
 def swagger_ui(
     schema_url: str = "/openapi.json",
-	swagger_ui_title: str = "Piccolo Swagger UI",
+    swagger_ui_title: str = "Piccolo Swagger UI",
     csrf_cookie_name: t.Optional[str] = DEFAULT_COOKIE_NAME,
     csrf_header_name: t.Optional[str] = DEFAULT_HEADER_NAME,
 ):
@@ -65,7 +65,7 @@ def swagger_ui(
             template = ENVIRONMENT.get_template("swagger_ui.html.jinja")
             html = template.render(
                 schema_url=schema_url,
-				swagger_ui_title=swagger_ui_title,
+                swagger_ui_title=swagger_ui_title,
                 csrf_cookie_name=csrf_cookie_name,
                 csrf_header_name=csrf_header_name,
             )

--- a/piccolo_api/openapi/templates/swagger_ui.html.jinja
+++ b/piccolo_api/openapi/templates/swagger_ui.html.jinja
@@ -3,7 +3,7 @@
 <head>
     <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css">
     <link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
-    <title>Piccolo Swagger UI</title>
+    <title>{{ swagger_ui_title }}</title>
 </head>
 
 <body>


### PR DESCRIPTION
Added the option to set a custom title for Swagger UI, like so:

```python
api.mount(
    "/docs/",
    swagger_ui(swagger_ui_title="My API docs", schema_url="../openapi.json"),
)
```

Defaults to "Piccolo Swagger UI"