### PR TITLE
add additional tests for the Starlette user

### DIFF
--- a/piccolo_api/shared/auth/user.py
+++ b/piccolo_api/shared/auth/user.py
@@ -24,7 +24,9 @@ class User(BaseUser):
 
     @property
     def user_id(self) -> int:
-        return t.cast(int, self.user._meta.primary_key)
+        return t.cast(
+            int, getattr(self.user, self.user._meta.primary_key._meta.name)
+        )
 
     @property
     def username(self) -> str:

--- a/tests/shared/auth/user.py
+++ b/tests/shared/auth/user.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from piccolo_api.shared.auth.user import PiccoloBaseUser, User
+
+
+class TestUser(TestCase):
+    def setUp(self):
+        PiccoloBaseUser.create_table(if_not_exists=True).run_sync()
+
+    def tearDown(self):
+        PiccoloBaseUser.alter().drop_table(if_exists=True).run_sync()
+
+    def test_user(self):
+        """
+        Make sure the attributes on the Starlette User map to the correct
+        values on the Piccolo user.
+        """
+        piccolo_user = PiccoloBaseUser(username="bob", password="bob123")
+        piccolo_user.save().run_sync()
+
+        starlette_user = User(user=piccolo_user)
+        self.assertEqual(starlette_user.user_id, piccolo_user.id)
+        self.assertEqual(starlette_user.identity, piccolo_user.id)
+        self.assertIsInstance(starlette_user.user_id, int)
+
+        self.assertEqual(starlette_user.username, piccolo_user.username)
+        self.assertEqual(starlette_user.username, "bob")

--- a/tests/shared/auth/user.py
+++ b/tests/shared/auth/user.py
@@ -13,7 +13,7 @@ class TestUser(TestCase):
     def test_user(self):
         """
         Make sure the attributes on the Starlette User map to the correct
-        values on the Piccolo user.
+        values on the Piccolo User.
         """
         piccolo_user = PiccoloBaseUser(username="bob", password="bob123")
         piccolo_user.save().run_sync()


### PR DESCRIPTION
A small regression crept in when fixing the MyPy errors.

This was due to insufficient test coverage on the `User` in `shared/auth/user.py`.

The PR adds additional test coverage.