### PR TITLE
Correctly add default values to created pydantic models

### DIFF
--- a/piccolo_api/crud/serializers.py
+++ b/piccolo_api/crud/serializers.py
@@ -112,7 +112,7 @@ def create_pydantic_model(
         #######################################################################
 
         params: t.Dict[str, t.Any] = {
-            "default": None if is_optional else ...,
+            "default": None if is_optional else column._meta.params.get("default") or ...,
             "nullable": column._meta.null,
         }
 


### PR DESCRIPTION
Right now default values are not being added (it's either `ellipsis` or `None` if we pass in `all_optional` as `True`). This is an issue because if people depend on the created `pydantic` schemas in their api endpoints the default values will not be parsed and will not be shown in `openapi` spec (eg. `pydantic` and `fastapi` schema generation).