### PR TITLE
require piccolo[postgres]

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo>=0.29.0
+piccolo[postgres]>=0.30.0
 pydantic>=1.6
 python-multipart>=0.0.5
 fastapi>=0.58.0


### PR DESCRIPTION
Piccolo API currently has a hard requirement on asyncpg:

https://github.com/piccolo-orm/piccolo_api/blob/4e4d55dc39b978f3d1a8f65b8e2974997b03b528/piccolo_api/crud/serializers.py#L9

Until we can work out how to make Piccolo API work gracefully without asyncpg installed, I'll add it to the requirements.