### PR TITLE
if `allow_unauthenticated=True`, don't reject if missing cookie

### DIFF
--- a/piccolo_api/session_auth/tables.py
+++ b/piccolo_api/session_auth/tables.py
@@ -59,7 +59,7 @@ class SessionsBase(Table, tablename="sessions"):
     @classmethod
     async def get_user_id(
         cls, token: str, increase_expiry: t.Optional[timedelta] = None
-    ) -> t.Union[int, t.Any]:
+    ) -> t.Optional[int]:
         """
         Returns the user_id if the given token is valid, otherwise None.
 
@@ -86,7 +86,7 @@ class SessionsBase(Table, tablename="sessions"):
                 )
                 await session.save().run()
 
-            return session.user_id
+            return t.cast(t.Optional[int], session.user_id)
         else:
             return None
 


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo_api/issues/89

`SessionAuthMiddleware` has an option called `allow_unauthenticated`. Rather than rejecting users if they don't have a valid session, it adds an `UnauthenticatedUser` user to the request, and it's up to the downstream code to handle this.

It's a useful feature, because sometimes you want a page which supports authenticated and non-authenticated users (for example, on a website's homepage).

There was a bug where it was a too aggressive about rejecting users when `allow_unauthenticated=True`.