### PR TITLE
remove body from 204 response

### DIFF
--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -797,7 +797,7 @@ class PiccoloCRUD(Router):
             await self.table.delete().where(
                 self.table._meta.primary_key == row_id
             ).run()
-            return Response("Deleted the resource.", status_code=204)
+            return Response(status_code=204)
         except ValueError:
             return Response("Unable to delete the resource.", status_code=500)
 


### PR DESCRIPTION
There's an issue where returning a 204 status code (which means no response) with a body can cause an error.

Hopefully it fixes https://github.com/piccolo-orm/piccolo_admin/issues/126