### PR TITLE
hooks

### DIFF
--- a/docs/source/crud/hooks.rst
+++ b/docs/source/crud/hooks.rst
@@ -36,7 +36,7 @@ Define an async method, and register it with PiccoloCRUD:
         ]
     )
 
-You can specify multiple hooks (also per hook_type). Hooks are executed in order. Only async methods (coroutines) are currently supported.
+You can specify multiple hooks (also per hook_type). Hooks are executed in order. You can use either async or regular functions.
 
 Hook types
 ---------------

--- a/docs/source/crud/hooks.rst
+++ b/docs/source/crud/hooks.rst
@@ -30,9 +30,9 @@ Define a method, and register it with PiccoloCRUD:
 
     # Register one or multiple hooks
     app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
-        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_10),
-        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_20),
-        Hook(hook_type=HookType.pre_delete, coro=pre_delete)
+        Hook(hook_type=HookType.pre_save, callable=set_movie_rating_10),
+        Hook(hook_type=HookType.pre_save, callable=set_movie_rating_20),
+        Hook(hook_type=HookType.pre_delete, callable=pre_delete)
         ]
     )
 
@@ -40,7 +40,7 @@ You can specify multiple hooks (also per hook_type). Hooks are executed in order
 You can use either async or regular functions.
 
 Hook types
----------------
+----------
 
 There are different hook types, and each type takes a slightly different set of inputs. 
 It's also important to return the expected data from your hook.
@@ -59,7 +59,7 @@ It takes a single parameter, ``row``, and should return the same:
 
 
     app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
-        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_10)
+        Hook(hook_type=HookType.pre_save, callable=set_movie_rating_10)
         ]
     )
 
@@ -79,13 +79,13 @@ Each function must return a dictionary which represent the data to be modified.
         return values
 
     app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
-        Hook(hook_type=HookType.pre_patch, coro=reset_name)
+        Hook(hook_type=HookType.pre_patch, callable=reset_name)
         ]
     )
 
 
 pre_delete
-~~~~~~~~~
+~~~~~~~~~~
 
 This hook runs during DELETE requests, prior to deleting the specified row in the database.
 It takes one parameter, ``row_id`` which is the id of the row to be deleted.
@@ -97,6 +97,6 @@ pre_delete hooks should not return data
         pass
 
     app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
-        Hook(hook_type=HookType.pre_delete, coro=pre_delete)
+        Hook(hook_type=HookType.pre_delete, callable=pre_delete)
         ]
     )

--- a/docs/source/crud/hooks.rst
+++ b/docs/source/crud/hooks.rst
@@ -6,7 +6,7 @@ Hooks allow executing custom code as part of processing a crud request. You can 
 Enabling a hook
 ---------------
 
-Define an async method, and register it with PiccoloCRUD:
+Define a method, and register it with PiccoloCRUD:
 
 .. code-block:: python
 
@@ -36,12 +36,14 @@ Define an async method, and register it with PiccoloCRUD:
         ]
     )
 
-You can specify multiple hooks (also per hook_type). Hooks are executed in order. You can use either async or regular functions.
+You can specify multiple hooks (also per hook_type). Hooks are executed in order. 
+You can use either async or regular functions.
 
 Hook types
 ---------------
 
-There are different hook types, and each type takes a slightly different set of inputs. It's also important to return the expected data from your hook
+There are different hook types, and each type takes a slightly different set of inputs. 
+It's also important to return the expected data from your hook.
 
 pre_save
 ~~~~~~~~
@@ -85,7 +87,7 @@ Each function must return a dictionary which represent the data to be modified.
 pre_delete
 ~~~~~~~~~
 
-This hook runs during PATCH requests, prior to changing the specified row in the database.
+This hook runs during DELETE requests, prior to deleting the specified row in the database.
 It takes one parameter, ``row_id`` which is the id of the row to be deleted.
 pre_delete hooks should not return data
 

--- a/docs/source/crud/hooks.rst
+++ b/docs/source/crud/hooks.rst
@@ -1,0 +1,100 @@
+Hooks
+=====
+
+Hooks allow executing custom code as part of processing a crud request. You can use this to validate data, call another custom api, place messages on queues and many other things.
+
+Enabling a hook
+---------------
+
+Define an async method, and register it with PiccoloCRUD:
+
+.. code-block:: python
+
+    # app.py
+    from piccolo_api.crud.endpoints import PiccoloCRUD
+
+    from movies.tables import Movie
+
+    # set movie rating to 10 before saving
+    async def set_movie_rating_10(row: Movie):
+        row.rating = 10
+        return row
+
+    # set movie rating to 20 before saving
+    async def set_movie_rating_10(row: Movie):
+        row.rating = 20
+        return row
+
+    async def pre_delete(row_id):
+        pass
+
+    # Register one or multiple hooks
+    app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
+        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_10),
+        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_20),
+        Hook(hook_type=HookType.pre_delete, coro=pre_delete)
+        ]
+    )
+
+You can specify multiple hooks (also per hook_type). Hooks are executed in order. Only async methods (coroutines) are currently supported.
+
+Hook types
+---------------
+
+There are different hook types, and each type takes a slightly different set of inputs. It's also important to return the expected data from your hook
+
+pre_save
+~~~~~~~~
+
+This hook runs during POST requests, prior to inserting data into the database.
+It takes a single parameter, ``row``, and should return the same:
+
+.. code-block:: python
+
+    async def set_movie_rating_10(row: Movie):
+        row.rating = 10
+        return row
+
+
+    app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
+        Hook(hook_type=HookType.pre_save, coro=set_movie_rating_10)
+        ]
+    )
+
+pre_patch
+~~~~~~~~~
+
+This hook runs during PATCH requests, prior to changing the specified row in the database.
+It takes two parameters, ``row_id`` which is the id of the row to be changed, and ``values`` which is a dictionary of incoming values.
+Each function must return a dictionary which represent the data to be modified.
+
+.. code-block:: python
+
+    async def reset_name(row_id: int, values: dict):
+        current_db_row = await Movie.objects().get(Movie.id==row_id).run()
+        if values.get("name"):
+            values["name"] = values["name"].replace(" ", "")
+        return values
+
+    app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
+        Hook(hook_type=HookType.pre_patch, coro=reset_name)
+        ]
+    )
+
+
+pre_delete
+~~~~~~~~~
+
+This hook runs during PATCH requests, prior to changing the specified row in the database.
+It takes one parameter, ``row_id`` which is the id of the row to be deleted.
+pre_delete hooks should not return data
+
+.. code-block:: python
+
+    async def pre_delete(row_id: int):
+        pass
+
+    app = PiccoloCRUD(table=Movie, read_only=False, hooks=[
+        Hook(hook_type=HookType.pre_delete, coro=pre_delete)
+        ]
+    )

--- a/docs/source/crud/index.rst
+++ b/docs/source/crud/index.rst
@@ -9,3 +9,4 @@ Piccolo tables into a powerful REST API.
 
     ./piccolo_crud
     ./serializers
+    ./hooks

--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -746,8 +746,9 @@ class PiccoloCRUD(Router):
 
         try:
             row = self.table(**model.dict())
-            for hook in [x for x in self.hooks if x.hook_type == HookType.pre_save]:
-                row = await hook.coro(row=row)
+            if self.hooks:
+                for hook in [x for x in self.hooks if x.hook_type == HookType.pre_save]:
+                    row = await hook.coro(row=row)
             response = await row.save().run()
             json = dump_json(response)
             # Returns the id of the inserted row.

--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -9,7 +9,13 @@ from dataclasses import dataclass, field
 import pydantic
 from piccolo.columns import Column, Where
 from piccolo.columns.column_types import Array, ForeignKey, Text, Varchar
-from piccolo_api.crud.hooks import Hook, HookType, execute_post_hooks, execute_patch_hooks, execute_delete_hooks
+from piccolo_api.crud.hooks import (
+    Hook,
+    HookType,
+    execute_post_hooks,
+    execute_patch_hooks,
+    execute_delete_hooks,
+)
 from piccolo.columns.operators import (
     Equal,
     GreaterEqualThan,
@@ -742,11 +748,11 @@ class PiccoloCRUD(Router):
         except ValidationError as exception:
             return Response(str(exception), status_code=400)
 
-
-
         try:
             row = self.table(**model.dict())
-            row = await execute_post_hooks(hooks=self.hooks, hook_type=HookType.pre_save, row=row)
+            row = await execute_post_hooks(
+                hooks=self.hooks, hook_type=HookType.pre_save, row=row
+            )
             response = await row.save().run()
             json = dump_json(response)
             # Returns the id of the inserted row.
@@ -979,7 +985,12 @@ class PiccoloCRUD(Router):
             )
 
         if self.hooks:
-            values = await execute_patch_hooks(hooks=self.hooks, hook_type=HookType.pre_patch, row_id=row_id, values=values)
+            values = await execute_patch_hooks(
+                hooks=self.hooks,
+                hook_type=HookType.pre_patch,
+                row_id=row_id,
+                values=values,
+            )
 
         try:
             await cls.update(values).where(
@@ -1002,7 +1013,9 @@ class PiccoloCRUD(Router):
         """
 
         if self.hooks:
-            await execute_delete_hooks(hooks=self.hooks, hook_type=HookType.pre_delete, row_id=row_id)
+            await execute_delete_hooks(
+                hooks=self.hooks, hook_type=HookType.pre_delete, row_id=row_id
+            )
 
         try:
             await self.table.delete().where(

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -16,21 +16,30 @@ class Hook:
         self.coro = coro
 
 
-async def execute_post_hooks(hooks: t.List[Hook], hook_type: HookType, row: Table):
+async def execute_post_hooks(
+    hooks: t.List[Hook], hook_type: HookType, row: Table
+):
     hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
     for hook in hooks_to_exec:
         row = await hook.coro(row)
     return row
 
 
-async def execute_patch_hooks(hooks: t.List[Hook], hook_type: HookType, row_id: t.Any, values: t.Dict[t.Any, t.Any]) -> t.Dict[t.Any, t.Any]:
+async def execute_patch_hooks(
+    hooks: t.List[Hook],
+    hook_type: HookType,
+    row_id: t.Any,
+    values: t.Dict[t.Any, t.Any],
+) -> t.Dict[t.Any, t.Any]:
     hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
     for hook in hooks_to_exec:
         values = await hook.coro(row_id=row_id, values=values)
     return values
 
 
-async def execute_delete_hooks(hooks: t.List[Hook], hook_type: HookType, row_id: t.Any):
+async def execute_delete_hooks(
+    hooks: t.List[Hook], hook_type: HookType, row_id: t.Any
+):
     hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
     for hook in hooks_to_exec:
         await hook.coro(row_id=row_id)

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -3,6 +3,7 @@ import typing as t
 from enum import Enum
 
 from piccolo.table import Table
+from typing import Dict
 
 
 class HookType(Enum):
@@ -18,7 +19,7 @@ class Hook:
 
 
 async def execute_post_hooks(
-    hooks: dict[HookType, t.List[Hook]], hook_type: HookType, row: Table
+    hooks: Dict[HookType, t.List[Hook]], hook_type: HookType, row: Table
 ):
     for hook in hooks.get(hook_type, []):
         if inspect.iscoroutinefunction(hook.callable):
@@ -29,7 +30,7 @@ async def execute_post_hooks(
 
 
 async def execute_patch_hooks(
-    hooks: dict[HookType, t.List[Hook]],
+    hooks: Dict[HookType, t.List[Hook]],
     hook_type: HookType,
     row_id: t.Any,
     values: t.Dict[t.Any, t.Any],
@@ -43,7 +44,7 @@ async def execute_patch_hooks(
 
 
 async def execute_delete_hooks(
-    hooks: dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any
+    hooks: Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any
 ):
     for hook in hooks.get(hook_type, []):
         if inspect.iscoroutinefunction(hook.callable):

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -3,7 +3,6 @@ import typing as t
 from enum import Enum
 
 from piccolo.table import Table
-from typing import Dict
 
 
 class HookType(Enum):
@@ -19,7 +18,7 @@ class Hook:
 
 
 async def execute_post_hooks(
-    hooks: Dict[HookType, t.List[Hook]], hook_type: HookType, row: Table
+    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row: Table
 ):
     for hook in hooks.get(hook_type, []):
         if inspect.iscoroutinefunction(hook.callable):
@@ -30,7 +29,7 @@ async def execute_post_hooks(
 
 
 async def execute_patch_hooks(
-    hooks: Dict[HookType, t.List[Hook]],
+    hooks: t.Dict[HookType, t.List[Hook]],
     hook_type: HookType,
     row_id: t.Any,
     values: t.Dict[t.Any, t.Any],
@@ -44,7 +43,7 @@ async def execute_patch_hooks(
 
 
 async def execute_delete_hooks(
-    hooks: Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any
+    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any
 ):
     for hook in hooks.get(hook_type, []):
         if inspect.iscoroutinefunction(hook.callable):

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class HookType(Enum):
+    pre_save = "pre_save"
+
+class Hook():
+    def __init__(self, hook_type: HookType, coro) -> None:
+        self.hook_type = hook_type
+        self.coro = coro

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -1,9 +1,36 @@
 from enum import Enum
+import typing as t
+
+from piccolo.table import Table
+
 
 class HookType(Enum):
     pre_save = "pre_save"
+    pre_patch = "pre_patch"
+    pre_delete = "pre_delete"
 
-class Hook():
+
+class Hook:
     def __init__(self, hook_type: HookType, coro) -> None:
         self.hook_type = hook_type
         self.coro = coro
+
+
+async def execute_post_hooks(hooks: t.List[Hook], hook_type: HookType, row: Table):
+    hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
+    for hook in hooks_to_exec:
+        row = await hook.coro(row)
+    return row
+
+
+async def execute_patch_hooks(hooks: t.List[Hook], hook_type: HookType, row_id: t.Any, values: t.Dict[t.Any, t.Any]) -> t.Dict[t.Any, t.Any]:
+    hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
+    for hook in hooks_to_exec:
+        values = await hook.coro(row_id=row_id, values=values)
+    return values
+
+
+async def execute_delete_hooks(hooks: t.List[Hook], hook_type: HookType, row_id: t.Any):
+    hooks_to_exec = [x for x in hooks if x.hook_type == hook_type]
+    for hook in hooks_to_exec:
+        await hook.coro(row_id=row_id)

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -1,0 +1,179 @@
+import json
+from unittest import TestCase
+
+from piccolo.columns import Integer, Varchar
+from piccolo.columns.readable import Readable
+from piccolo.table import Table
+from starlette.testclient import TestClient
+
+from piccolo_api.crud.endpoints import (
+    PiccoloCRUD,
+)
+from piccolo_api.crud.hooks import Hook, HookType
+
+
+class Movie(Table):
+    name = Varchar(length=100, required=True)
+    rating = Integer()
+
+    @classmethod
+    def get_readable(cls):
+        return Readable(template="%s", columns=[cls.name])
+
+
+async def set_movie_rating_10(row: Movie):
+    row.rating = 10
+    return row
+
+
+async def set_movie_rating_20(row: Movie):
+    row.rating = 20
+    return row
+
+
+async def remove_spaces(row_id: int, values: dict):
+    values["name"] = values["name"].replace(" ", "")
+    return values
+
+
+async def look_up_existing(row_id: int, values: dict):
+    row = await Movie.objects().get(Movie.id==row_id).run()
+    values["name"] = row.name
+    return values
+
+
+async def failing_hook(row_id: int):
+    raise Exception("hook failed")
+
+
+class TestPostHooks(TestCase):
+    def setUp(self):
+        Movie.create_table(if_not_exists=True).run_sync()
+
+    def tearDown(self):
+        Movie.alter().drop_table().run_sync()
+
+    def test_single_pre_post_hook(self):
+        """
+        Make sure single hook executes
+        """
+        client = TestClient(PiccoloCRUD(
+            table=Movie, read_only=False,
+            hooks=[
+                Hook(
+                    hook_type=HookType.pre_save,
+                    coro=set_movie_rating_10
+                )
+            ]
+        ))
+        json = {"name": "Star Wars", "rating": 93}
+        response = client.post("/", json=json)
+        movie = Movie.objects().first().run_sync()
+        self.assertEqual(movie.rating, 10)
+
+    def test_multi_pre_post_hooks(self):
+        """
+        Make sure multiple hooks execute in correct order
+        """
+        client = TestClient(PiccoloCRUD(
+            table=Movie, read_only=False,
+            hooks=[
+                Hook(
+                    hook_type=HookType.pre_save,
+                    coro=set_movie_rating_10
+                ),
+                Hook(
+                    hook_type=HookType.pre_save,
+                    coro=set_movie_rating_20
+                )
+            ]
+        ))
+        json = {"name": "Star Wars", "rating": 93}
+        response = client.post("/", json=json)
+        movie = Movie.objects().first().run_sync()
+        self.assertEqual(movie.rating, 20)
+
+
+    def test_pre_patch_hook(self):
+        """
+        Make sure pre_patch hook executes successfully
+        """
+        client = TestClient(PiccoloCRUD(
+            table=Movie,
+            read_only=False,
+            hooks=[
+                Hook(
+                    hook_type=HookType.pre_patch,
+                    coro=remove_spaces
+                )
+            ]
+        ))
+
+        movie = Movie(name="Star Wars", rating=93)
+        movie.save().run_sync()
+
+        new_name = "Star Wars: A New Hope"
+        new_name_modified = new_name.replace(" ", "")
+
+        response = client.patch(f"/{movie.id}/", json={"name": new_name})
+        self.assertTrue(response.status_code == 200)
+
+        # Make sure the row is returned:
+        response_json = json.loads(response.json())
+        self.assertTrue(response_json["name"] == new_name_modified)
+
+        # Make sure the underlying database row was changed:
+        movies = Movie.select().run_sync()
+        self.assertTrue(movies[0]["name"] == new_name_modified)
+
+    def test_pre_patch_hook_db_lookup(self):
+        """
+        Make sure pre_patch hook can perform db lookups (function will always reset "name" to the original name)
+        """
+        client = TestClient(PiccoloCRUD(
+            table=Movie,
+            read_only=False,
+            hooks=[
+                Hook(
+                    hook_type=HookType.pre_patch,
+                    coro=look_up_existing
+                )
+            ]
+        ))
+
+        original_name = "Star Wars"
+        movie = Movie(name="Star Wars", rating=93)
+        movie.save().run_sync()
+
+        new_name = "Star Wars: A New Hope"
+
+        response = client.patch(f"/{movie.id}/", json={"name": new_name})
+        self.assertTrue(response.status_code == 200)
+
+        response_json = json.loads(response.json())
+        self.assertTrue(response_json["name"] == original_name)
+
+        movies = Movie.select().run_sync()
+        self.assertTrue(movies[0]["name"] == original_name)
+
+
+    def test_delete_hook_fails(self):
+        """
+        Make sure failing pre_delete hook bubbles up (this implicitly also tests that pre_delete hooks execute)
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie, read_only=False,
+                hooks=[
+                    Hook(hook_type=HookType.pre_delete, coro=failing_hook)
+                ]
+
+            )
+
+        )
+
+        movie = Movie(name="Star Wars", rating=10)
+        movie.save().run_sync()
+
+        with self.assertRaises(Exception):
+            response = client.delete(f"/{movie.id}/")

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -20,12 +20,12 @@ class Movie(Table):
 
 
 async def set_movie_rating_10(row: Movie):
-    row.rating = 10  # type: ignore
+    row["rating"] = 10
     return row
 
 
 async def set_movie_rating_20(row: Movie):
-    row.rating = 20  # type: ignore
+    row["rating"] = 20
     return row
 
 


### PR DESCRIPTION
As an alternative to adding hooks/signals to piccolo-orm itself, I wanted to explore if such functionality could be more easily added to piccolo-api instead. My goal is to have extensibility points in piccolo-api (and maybe thereby also in piccolo-admin) that expand on the existing crud operations.

My propsal is that `PiccoloCRUD` taks an optional `hooks` parameter, which is a list of coroutines and when to trigger them. So far I've only added `pre_save` as a proof of concept. This lets me create a test app looking like this (i've just snipped the relevant parts of the app:

```
class Customer(Table):
    email: str = Varchar(null=True, default=None)
    first_name: str = Varchar(null=True, default=None)
    last_name: str = Varchar(null=True, default=None)


class NiceCustomer(BaseModel):
    email: str = None


async def awesome_hook(row: Customer):
    dict_row = row.to_dict()
    model_thing = NiceCustomer(**dict_row)
    async with httpx.AsyncClient() as client:
        r = await client.post(
            "https://good-url.example.com",
            json=model_thing.dict()
        )


FastAPIWrapper(
    root_url="/api/v2/customer/",
    fastapi_app=app,
    piccolo_crud=PiccoloCRUD(
        page_size=50,
        table=Customer,
        read_only=False,
        hooks=[
            Hook(
                hook_type=HookType.pre_save,
                coro=awesome_hook
            )
        ]
    )
)


```

I'd be happy to continue building on this, but I want to get maintainer's initial feedback first.