### PR TITLE
dont pass __range_header param to model validator if value is non-truthy

### DIFF
--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -592,8 +592,9 @@ class PiccoloCRUD(Router):
                 response.include_readable = True
                 continue
 
-            if key == "__range_header" and value in ("true", "True", "1"):
-                response.range_header = True
+            if key == "__range_header":
+                if value in ("true", "True", "1"):
+                    response.range_header = True
                 continue
 
             if key == "__range_header_name":

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -1262,6 +1262,23 @@ class RangeHeaders(TestCase):
         self.assertEqual(0, len(response_json["rows"]))
         self.assertEqual(response.headers.get("Content-Range"), "movies 0-0/0")
 
+    def test_false_range_header_param(self):
+        """
+        Make sure that __range_header=false is supported
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie,
+                read_only=False,
+            )
+        )
+
+        response = client.get(
+            "/?__range_header=false"
+        )
+        self.assertTrue(response.status_code == 200)
+        self.assertEqual(response.headers.get("Content-Range"), None)
+
     def test_empty_list(self):
         """
         Make sure the content-range header responds correctly for empty rows


### PR DESCRIPTION
fixes a bug where `?__range_header=false` wasn't handled correctly.