### PR TITLE
make patch response json/dict instead of string

### DIFF
--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -1044,7 +1044,7 @@ class PiccoloCRUD(Router):
                 .first()
                 .run()
             )
-            return JSONResponse(self.pydantic_model(**new_row).json())
+            return CustomJSONResponse(self.pydantic_model(**new_row).json())
         except ValueError:
             return Response("Unable to save the resource.", status_code=500)
 

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 from unittest import TestCase
 
@@ -123,9 +122,10 @@ class TestPatch(TestCase):
 
         response = client.patch(f"/{movie.id}/", json={"name": new_name})
         self.assertTrue(response.status_code == 200)
+        self.assertIsInstance(response.json(), dict)
 
         # Make sure the row is returned:
-        response_json = json.loads(response.json())
+        response_json = response.json()
         self.assertTrue(response_json["name"] == new_name)
         self.assertTrue(response_json["rating"] == rating)
 
@@ -1273,9 +1273,7 @@ class RangeHeaders(TestCase):
             )
         )
 
-        response = client.get(
-            "/?__range_header=false"
-        )
+        response = client.get("/?__range_header=false")
         self.assertTrue(response.status_code == 200)
         self.assertEqual(response.headers.get("Content-Range"), None)
 

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from piccolo.columns import Integer, Varchar
@@ -121,7 +120,7 @@ class TestPostHooks(TestCase):
         self.assertTrue(response.status_code == 200)
 
         # Make sure the row is returned:
-        response_json = json.loads(response.json())
+        response_json = response.json()
         self.assertTrue(response_json["name"] == new_name_modified)
 
         # Make sure the underlying database row was changed:
@@ -154,7 +153,7 @@ class TestPostHooks(TestCase):
         response = client.patch(f"/{movie.id}/", json={"name": new_name})
         self.assertTrue(response.status_code == 200)
 
-        response_json = json.loads(response.json())
+        response_json = response.json()
         self.assertTrue(response_json["name"] == original_name)
 
         movies = Movie.select().run_sync()

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from fastapi import FastAPI
@@ -219,9 +218,7 @@ class TestResponses(TestCase):
         client = TestClient(app)
         response = client.patch("/movies/1/", json={"rating": 90})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json(), json.dumps({"name": "Star Wars", "rating": 90})
-        )
+        self.assertEqual(response.json(), {"name": "Star Wars", "rating": 90})
 
         response = client.get("/movies/1/")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
changes patch response so that it's a proper json instead of a json-formatted string. This also means that tests no longer have to convert the string response to dict before comparing so that's a nice added bonus - a bit cleaner overall.

fixes #126