### PR TITLE
add docs for session auth clean command

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ autodoc_typehints = "signature"
 autodoc_typehints_format = "short"
 autoclass_content = "both"
 autodoc_type_aliases = {"ASGIApp": "ASGIApp"}
+html_short_title = "Piccolo API"
 
 # -- Intersphinx -------------------------------------------------------------
 

--- a/docs/source/session_auth/commands.rst
+++ b/docs/source/session_auth/commands.rst
@@ -1,0 +1,16 @@
+Commands
+========
+
+If you've registered the ``session_auth`` app in your ``piccolo_conf.py`` file
+(see the :ref:`migrations docs <SessionMigrations>`), it gives you access to a
+custom command.
+
+clean
+-----
+
+If you run the following on the command line, it will delete any old sessions
+from the database.
+
+.. code-block:: bash
+
+    piccolo session_auth clean

--- a/docs/source/session_auth/index.rst
+++ b/docs/source/session_auth/index.rst
@@ -10,4 +10,5 @@ Session Auth
     ./tables
     ./endpoints
     ./middleware
+    ./commands
     ./example

--- a/docs/source/session_auth/introduction.rst
+++ b/docs/source/session_auth/introduction.rst
@@ -11,4 +11,4 @@ has a valid session.
 There are several advantages to session auth:
 
 * A session can be invalidated at any time, by deleting a session from the database.
-* HTTP-only cookies are immune to tampering with Javascript.
+* HTTP-only cookies are immune to tampering with JavaScript.

--- a/docs/source/session_auth/tables.rst
+++ b/docs/source/session_auth/tables.rst
@@ -6,6 +6,8 @@ and the user credentials in :class:`BaseUser <piccolo.apps.user.tables.BaseUser>
 
 -------------------------------------------------------------------------------
 
+.. _SessionMigrations:
+
 Migrations
 ----------
 

--- a/docs/source/token_auth/index.rst
+++ b/docs/source/token_auth/index.rst
@@ -22,7 +22,7 @@ tokens can be securely stored on the device. The client logic is simple to
 implement, as you don't have to worry about refreshing your token.
 
 It's not recommended to use this type of authentication with web apps, because
-you can't securely store the token using Javascript, which makes it
+you can't securely store the token using JavaScript, which makes it
 susceptible to exposure using a XSS attack.
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The `session_auth` app has a custom command for clearing out old sessions from the database:

```
piccolo session_auth clean
```

It wasn't documented though, which is what this PR adds.