### PR TITLE
Custom template styles via CSS variables

### DIFF
--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -18,3 +18,10 @@ CAPTCHA
 .. autofunction:: hcaptcha
 
 .. autofunction:: recaptcha_v2
+
+Styles
+------
+
+.. currentmodule:: piccolo_api.shared.auth.styles
+
+.. autoclass:: Styles

--- a/example_projects/register_demo/app.py
+++ b/example_projects/register_demo/app.py
@@ -11,6 +11,7 @@ from piccolo_api.shared.auth.captcha import (
     hcaptcha,
     recaptcha_v2,
 )
+from piccolo_api.shared.auth.styles import Styles
 
 
 class RegisterSuccess(HTTPEndpoint):
@@ -28,6 +29,7 @@ class RegisterSuccess(HTTPEndpoint):
                 '<p><a href="/register/">Register</a></p>'
                 '<p><a href="/register/hcaptcha/">Register with hCaptcha</a></p>'  # noqa: E501
                 '<p><a href="/register/recaptcha/">Register with reCAPTCHA</a></p>'  # noqa: E501
+                '<p><a href="/register/custom-styles/">Register with custom styles</a></p>'  # noqa: E501
             )
         )
 
@@ -57,7 +59,22 @@ app = Starlette(
                 redirect_to="/",
             ),
         ),
-        # Not using a captcha
+        # Custom styles
+        Mount(
+            "/register/custom-styles/",
+            register(
+                redirect_to="/",
+                styles=Styles(
+                    background_color="green",
+                    text_color="white",
+                    foreground_color="black",
+                    button_color="orange",
+                    button_text_color="yellow",
+                    error_text_color="yellow",
+                ),
+            ),
+        ),
+        # Basic
         Mount(
             "/register/",
             register(redirect_to="/"),

--- a/example_projects/register_demo/requirements.txt
+++ b/example_projects/register_demo/requirements.txt
@@ -1,5 +1,5 @@
 starlette
-uvicorn
+uvicorn[all]
 piccolo[postgres]
 httpx
 python-multipart

--- a/piccolo_api/register/endpoints.py
+++ b/piccolo_api/register/endpoints.py
@@ -14,11 +14,13 @@ from starlette.exceptions import HTTPException
 from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
 
-from piccolo_api.shared.auth.captcha import Captcha
+from piccolo_api.shared.auth.styles import Styles
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from jinja2 import Template
     from starlette.responses import Response
+
+    from piccolo_api.shared.auth.captcha import Captcha
 
 
 SIGNUP_TEMPLATE_PATH = os.path.join(
@@ -53,6 +55,10 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
     def _captcha(self) -> t.Optional[Captcha]:
         raise NotImplementedError
 
+    @abstractproperty
+    def _styles(self) -> Styles:
+        raise NotImplementedError
+
     def render_template(
         self, request: Request, template_context: t.Dict[str, t.Any] = {}
     ) -> HTMLResponse:
@@ -69,6 +75,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 csrf_cookie_name=csrf_cookie_name,
                 request=request,
                 captcha=self._captcha,
+                styles=self._styles,
                 **template_context,
             )
         )
@@ -182,6 +189,7 @@ def register(
     template_path: t.Optional[str] = None,
     user_defaults: t.Optional[t.Dict[str, t.Any]] = None,
     captcha: t.Optional[Captcha] = None,
+    styles: t.Optional[Styles] = None,
 ) -> t.Type[RegisterEndpoint]:
     """
     An endpoint for register user.
@@ -223,5 +231,6 @@ def register(
         _register_template = register_template
         _user_defaults = user_defaults
         _captcha = captcha
+        _styles = styles or Styles()
 
     return _RegisterEndpoint

--- a/piccolo_api/register/endpoints.py
+++ b/piccolo_api/register/endpoints.py
@@ -215,6 +215,8 @@ def register(
     :param captcha:
         Integrate a CAPTCHA service, to provide protection against bots.
         See :class:`Captcha <piccolo_api.shared.auth.captcha.Captcha>`.
+    :param styles:
+        Modify the appearance of the HTML template using CSS.
 
     """
     template_path = (

--- a/piccolo_api/session_auth/endpoints.py
+++ b/piccolo_api/session_auth/endpoints.py
@@ -370,6 +370,8 @@ def session_login(
     :param captcha:
         Integrate a CAPTCHA service, to provide protection against bots.
         See :class:`Captcha <piccolo_api.shared.auth.captcha.Captcha>`.
+    :param styles:
+        Modify the appearance of the HTML template using CSS.
 
     """  # noqa: E501
     template_path = (
@@ -420,6 +422,9 @@ def session_logout(
         ``'/some_directory/logout.html'``. Refer to the default template at
         ``piccolo_api/templates/logout.html`` as a basis for your
         custom template.
+    :param styles:
+        Modify the appearance of the HTML template using CSS.
+
     """  # noqa: E501
     template_path = (
         LOGOUT_TEMPLATE_PATH if template_path is None else template_path

--- a/piccolo_api/shared/auth/styles.py
+++ b/piccolo_api/shared/auth/styles.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Styles:
+    background_color: str = "#eef2f5"
+    foreground_color: str = "white"
+    text_color: str = "black"
+    error_text_color: str = "red"
+    button_color: str = "#419EF8"
+    button_text_color: str = "white"

--- a/piccolo_api/shared/auth/styles.py
+++ b/piccolo_api/shared/auth/styles.py
@@ -13,7 +13,7 @@ class Styles:
 
     """
 
-    background_color: str = "#eef2f5"
+    background_color: str = "#EEF2F5"
     foreground_color: str = "white"
     text_color: str = "black"
     error_text_color: str = "red"

--- a/piccolo_api/shared/auth/styles.py
+++ b/piccolo_api/shared/auth/styles.py
@@ -3,6 +3,14 @@ from dataclasses import dataclass
 
 @dataclass
 class Styles:
+    """
+    Used to set CSS styles in endpoints such as
+    :func:`session_login <piccolo_api.session_auth.endpoints.session_login>`,
+    :func:`session_logout <piccolo_api.session_auth.endpoints.session_logout>`,
+    and :func:`register <piccolo_api.register.endpoints.register>`.
+
+    """
+
     background_color: str = "#eef2f5"
     foreground_color: str = "white"
     text_color: str = "black"

--- a/piccolo_api/shared/auth/styles.py
+++ b/piccolo_api/shared/auth/styles.py
@@ -9,6 +9,8 @@ class Styles:
     :func:`session_logout <piccolo_api.session_auth.endpoints.session_logout>`,
     and :func:`register <piccolo_api.register.endpoints.register>`.
 
+    Each of the values must be valid CSS.
+
     """
 
     background_color: str = "#eef2f5"

--- a/piccolo_api/templates/base.html
+++ b/piccolo_api/templates/base.html
@@ -11,9 +11,19 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
 
     <style>
+        :root {
+            --background_color: {{ styles.background_color }};
+            --foreground_color: {{ styles.foreground_color }};
+            --text_color: {{ styles.text_color }};
+            --error_text_color: {{ styles.error_text_color }};
+            --button_color: {{ styles.button_color }};
+            --button_text_color: {{ styles.button_text_color }};
+        }
+
         body {
-            background-color: #eef2f5;
+            background-color: var(--background_color);
             font-family: "Open Sans", sans-serif;
+            color: var(--text_color);
         }
 
         div.content {
@@ -25,7 +35,7 @@
         }
 
         div.form_wrapper {
-            background-color: white;
+            background-color: var(--foreground_color);
             flex-grow: 0;
             margin: 0 auto;
             max-width: 25rem;
@@ -42,7 +52,7 @@
 
         p.error {
             font-size: 0.9rem;
-            color: red;
+            color: var(--error_text_color);
         }
 
         label {
@@ -68,9 +78,9 @@
         }
 
         button {
-            background-color: #419EF8;
+            background-color: var(--button_color);
             border: none;
-            color: white;
+            color: var(--button_text_color);
             cursor: pointer;
             display: block;
             font-size: 0.8rem;

--- a/tests/shared/auth/test_styles.py
+++ b/tests/shared/auth/test_styles.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from starlette.routing import Route, Router
+from starlette.testclient import TestClient
+
+from piccolo_api.register.endpoints import register
+from piccolo_api.session_auth.endpoints import session_login, session_logout
+from piccolo_api.shared.auth.styles import Styles
+
+
+class TestStyles(TestCase):
+    def test_styles(self):
+        """
+        Make sure the custom styles are shown in the HTML output.
+        """
+        custom_styles = Styles(background_color="black")
+        app = Router(
+            routes=[
+                Route(
+                    "/login/",
+                    session_login(styles=custom_styles),
+                ),
+                Route(
+                    "/logout/",
+                    session_logout(styles=custom_styles),
+                ),
+                Route(
+                    "/register/",
+                    register(styles=custom_styles),
+                ),
+            ]
+        )
+        client = TestClient(app)
+
+        for url in ("/login/", "/logout/", "/register/"):
+            response = client.get(url)
+            self.assertTrue(b"--background_color: black;" in response.content)


### PR DESCRIPTION
Closes https://github.com/piccolo-orm/piccolo_api/issues/140

It's now possible to customise the style of the `session_login` and `register` templates to match your application. You can go totally crazy ( I don't recommend this colour scheme 😄 ):

<img width="606" alt="Screenshot 2022-06-05 at 12 02 07" src="https://user-images.githubusercontent.com/350976/172047536-73cf7abc-2bc7-4f88-9e3b-5dfab97e10b5.png">

Things left to do:

- [x] Update the docs
- [x] Add custom styles to `session_login` and `session_logout`
- [x] Add some tests somehow?