### PR TITLE
`confirm_password` -> `confirm_new_password`

### DIFF
--- a/docs/source/change_password/index.rst
+++ b/docs/source/change_password/index.rst
@@ -17,7 +17,7 @@ change their password manually.
 
 Alternatively, you can change the password programatically by sending a POST
 request to this endpoint (passing in ``old_password``, ``new_password`` and
-``confirm_password`` parameters as JSON, or as form data).
+``confirm_new_password`` parameters as JSON, or as form data).
 
 When the password change is successful, we invalidate the session cookie, and
 redirect the user to the login endpoint.

--- a/piccolo_api/change_password/endpoints.py
+++ b/piccolo_api/change_password/endpoints.py
@@ -97,12 +97,16 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
 
         old_password = body.get("old_password", None)
         new_password = body.get("new_password", None)
-        confirm_password = body.get("confirm_password", None)
+        confirm_new_password = body.get("confirm_new_password", None)
 
         piccolo_user = request.user.user
         min_password_length = piccolo_user._min_password_length
 
-        if (not old_password) or (not new_password) or (not confirm_password):
+        if (
+            (not old_password)
+            or (not new_password)
+            or (not confirm_new_password)
+        ):
             error = "Form is invalid. Missing one or more fields."
             if body.get("format") == "html":
                 return self.render_template(
@@ -129,7 +133,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     detail=error,
                 )
 
-        if confirm_password != new_password:
+        if confirm_new_password != new_password:
             error = "Passwords do not match."
 
             if body.get("format") == "html":

--- a/piccolo_api/templates/change_password.html
+++ b/piccolo_api/templates/change_password.html
@@ -17,7 +17,7 @@
         <label>New Password ({{ min_password_length }} characters minimum)</label>
         <input type="password" name="new_password" minlength={{ min_password_length }} required />
         <label>Confirm New Password</label>
-        <input type="password" name="confirm_password" minlength={{ min_password_length }} required />
+        <input type="password" name="confirm_new_password" minlength={{ min_password_length }} required />
 
         {% if csrftoken and csrf_cookie_name %}
             <input type="hidden" name="{{ csrf_cookie_name }}" value="{{ csrftoken }}" />

--- a/tests/session_auth/test_session.py
+++ b/tests/session_auth/test_session.py
@@ -473,7 +473,7 @@ class TestSessions(SessionTestCase):
             json={
                 "old_password": f"{self.credentials['password']}",
                 "new_password": "newpass123",
-                "confirm_password": "newpass123",
+                "confirm_new_password": "newpass123",
             },
         )
         self.assertEqual(response.status_code, 303)
@@ -495,7 +495,7 @@ class TestSessions(SessionTestCase):
             json={
                 "old_password": "bob1234",
                 "new_password": "newpass123",
-                "confirm_password": "newpass123",
+                "confirm_new_password": "newpass123",
             },
         )
         self.assertEqual(response.status_code, 401)
@@ -518,7 +518,7 @@ class TestSessions(SessionTestCase):
             json={
                 "old_password": f"{self.credentials['password']}",
                 "new_password": "newpass123",
-                "confirm_password": "newpass123",
+                "confirm_new_password": "newpass123",
             },
         )
         self.assertEqual(response.status_code, 303)
@@ -562,7 +562,7 @@ class TestSessions(SessionTestCase):
             json={
                 "old_password": f"{self.credentials['password']}",
                 "new_password": "john",
-                "confirm_password": "john123",
+                "confirm_new_password": "john123",
             },
         )
         self.assertEqual(response.status_code, 401)
@@ -587,7 +587,7 @@ class TestSessions(SessionTestCase):
             json={
                 "old_password": f"{self.credentials['password']}",
                 "new_password": "john123",
-                "confirm_password": "john1234",
+                "confirm_new_password": "john1234",
             },
         )
         self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
@sinisaos I made a slight modification.

The parameters were `old_password`, `new_password`, and `confirm_password`.

I've changed `confirm_password` to `confirm_new_password`, as it's slightly ambiguous otherwise - are you confirming the old password, or the new one?

Most people would guess that you're confirming the new password, but best to be more explicit.