### PR TITLE
old password -> current password

### DIFF
--- a/piccolo_api/change_password/endpoints.py
+++ b/piccolo_api/change_password/endpoints.py
@@ -95,7 +95,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
             except JSONDecodeError:
                 body = await request.form()
 
-        old_password = body.get("old_password", None)
+        current_password = body.get("current_password", None)
         new_password = body.get("new_password", None)
         confirm_new_password = body.get("confirm_new_password", None)
 
@@ -103,7 +103,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
         min_password_length = piccolo_user._min_password_length
 
         if (
-            (not old_password)
+            (not current_password)
             or (not new_password)
             or (not confirm_new_password)
         ):
@@ -146,7 +146,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 raise HTTPException(status_code=401, detail=error)
 
         if not await piccolo_user.login(
-            username=piccolo_user.username, password=old_password
+            username=piccolo_user.username, password=current_password
         ):
             error = "Incorrect password."
             if body.get("format") == "html":

--- a/piccolo_api/templates/change_password.html
+++ b/piccolo_api/templates/change_password.html
@@ -12,8 +12,8 @@
     <p class="hint">Logged in as {{ username }}.</p>
 
     <form method="POST">
-        <label>Old Password</label>
-        <input type="password" name="old_password" required />
+        <label>Current Password</label>
+        <input type="password" name="current_password" required />
         <label>New Password ({{ min_password_length }} characters minimum)</label>
         <input type="password" name="new_password" minlength={{ min_password_length }} required />
         <label>Confirm New Password</label>

--- a/tests/session_auth/test_session.py
+++ b/tests/session_auth/test_session.py
@@ -456,7 +456,7 @@ class TestSessions(SessionTestCase):
         )
         self.assertTrue(b"<h1>Change Password</h1>" in response.content)
 
-    def test_correct_old_password(self):
+    def test_correct_current_password(self):
         """
         Make sure a POST request to `change_password` works.
         """
@@ -471,14 +471,14 @@ class TestSessions(SessionTestCase):
             "/change-password/",
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={
-                "old_password": f"{self.credentials['password']}",
+                "current_password": f"{self.credentials['password']}",
                 "new_password": "newpass123",
                 "confirm_new_password": "newpass123",
             },
         )
         self.assertEqual(response.status_code, 303)
 
-    def test_wrong_old_password(self):
+    def test_wrong_current_password(self):
         """
         Make sure a POST request to `change_password` works.
         """
@@ -493,7 +493,7 @@ class TestSessions(SessionTestCase):
             "/change-password/",
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={
-                "old_password": "bob1234",
+                "current_password": "bob1234",
                 "new_password": "newpass123",
                 "confirm_new_password": "newpass123",
             },
@@ -516,7 +516,7 @@ class TestSessions(SessionTestCase):
             "/change-password/",
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={
-                "old_password": f"{self.credentials['password']}",
+                "current_password": f"{self.credentials['password']}",
                 "new_password": "newpass123",
                 "confirm_new_password": "newpass123",
             },
@@ -560,7 +560,7 @@ class TestSessions(SessionTestCase):
             "/change-password/",
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={
-                "old_password": f"{self.credentials['password']}",
+                "current_password": f"{self.credentials['password']}",
                 "new_password": "john",
                 "confirm_new_password": "john123",
             },
@@ -585,7 +585,7 @@ class TestSessions(SessionTestCase):
             "/change-password/",
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={
-                "old_password": f"{self.credentials['password']}",
+                "current_password": f"{self.credentials['password']}",
                 "new_password": "john123",
                 "confirm_new_password": "john1234",
             },


### PR DESCRIPTION
Having researched some other change password forms, 'current password' makes more sense than 'old password'.