### PR TITLE
improve http status codes

### DIFF
--- a/piccolo_api/change_password/endpoints.py
+++ b/piccolo_api/change_password/endpoints.py
@@ -127,7 +127,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     template_context={"error": error},
                     min_password_length=min_password_length,
                 )
-            raise HTTPException(status_code=401, detail=error)
+            raise HTTPException(status_code=422, detail=error)
 
         if len(new_password) < min_password_length:
             error = (
@@ -142,7 +142,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 )
             else:
                 raise HTTPException(
-                    status_code=401,
+                    status_code=422,
                     detail=error,
                 )
 
@@ -156,7 +156,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     template_context={"error": error},
                 )
             else:
-                raise HTTPException(status_code=401, detail=error)
+                raise HTTPException(status_code=422, detail=error)
 
         if not await piccolo_user.login(
             username=piccolo_user.username, password=current_password
@@ -168,7 +168,7 @@ class ChangePasswordEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     min_password_length=min_password_length,
                     template_context={"error": error},
                 )
-            raise HTTPException(detail=error, status_code=401)
+            raise HTTPException(detail=error, status_code=422)
 
         await piccolo_user.update_password(
             user=request.user.user_id, password=new_password

--- a/piccolo_api/register/endpoints.py
+++ b/piccolo_api/register/endpoints.py
@@ -135,7 +135,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     },
                 )
             raise HTTPException(
-                status_code=401,
+                status_code=422,
                 detail="Form is invalid. Missing one or more fields.",
             )
 
@@ -147,7 +147,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 )
             else:
                 raise HTTPException(
-                    status_code=401, detail="Invalid email address."
+                    status_code=422, detail="Invalid email address."
                 )
 
         if len(password) < 6:
@@ -160,7 +160,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 )
             else:
                 raise HTTPException(
-                    status_code=401,
+                    status_code=422,
                     detail="Password must be at least 6 characters long.",
                 )
 
@@ -172,7 +172,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 )
             else:
                 raise HTTPException(
-                    status_code=401, detail="Passwords do not match."
+                    status_code=422, detail="Passwords do not match."
                 )
 
         if await self._auth_table.count().where(
@@ -188,7 +188,7 @@ class RegisterEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                 )
             else:
                 raise HTTPException(
-                    status_code=401,
+                    status_code=422,
                     detail="User with email or username already exists.",
                 )
 

--- a/piccolo_api/session_auth/endpoints.py
+++ b/piccolo_api/session_auth/endpoints.py
@@ -215,7 +215,7 @@ class SessionLoginEndpoint(HTTPEndpoint, metaclass=ABCMeta):
                     template_context={"error": error_message},
                 )
             else:
-                raise HTTPException(status_code=401, detail=error_message)
+                raise HTTPException(status_code=422, detail=error_message)
 
         # Run pre_login hooks
         if self._hooks and self._hooks.pre_login:

--- a/tests/session_auth/test_session.py
+++ b/tests/session_auth/test_session.py
@@ -156,7 +156,7 @@ class TestSessions(SessionTestCase):
         """
         client = TestClient(APP)
         response = client.post("/register/", json={})
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.content, b"Form is invalid. Missing one or more fields."
         )
@@ -175,7 +175,7 @@ class TestSessions(SessionTestCase):
                 "confirm_password": "john123",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(response.content, b"Invalid email address.")
 
     def test_register_password_length(self):
@@ -192,7 +192,7 @@ class TestSessions(SessionTestCase):
                 "confirm_password": "john",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.content, b"Password must be at least 6 characters long."
         )
@@ -211,7 +211,7 @@ class TestSessions(SessionTestCase):
                 "confirm_password": "john",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(response.content, b"Passwords do not match.")
 
     def test_register_user_already_exist(self):
@@ -223,7 +223,7 @@ class TestSessions(SessionTestCase):
             username="John", email="john@example.com", password="john123"
         ).save().run_sync()
         response = client.post("/register/", json=self.register_credentials)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.content, b"User with email or username already exists."
         )
@@ -498,7 +498,7 @@ class TestSessions(SessionTestCase):
                 "confirm_new_password": "newpass123",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertTrue(response.content, b"Incorrect password.")
 
     def test_change_password_success(self):
@@ -540,7 +540,7 @@ class TestSessions(SessionTestCase):
             cookies={"id": f"{response.cookies.values()[0]}"},
             json={},
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.content, b"Form is invalid. Missing one or more fields."
         )
@@ -565,7 +565,7 @@ class TestSessions(SessionTestCase):
                 "confirm_new_password": "john123",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.content, b"Password must be at least 6 characters long."
         )
@@ -590,7 +590,7 @@ class TestSessions(SessionTestCase):
                 "confirm_new_password": "john1234",
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(response.content, b"Passwords do not match.")
 
     def test_change_password_get_template_no_authenticated(self):


### PR DESCRIPTION
Some of the HTTP status codes were correct - they were returning 401, which means permission denied, when 422 is more appropriate, as they are validation errors.

This is important for Piccolo Admin, as we configure axios to intercept any 401 errors, and redirect to the login page.