### PR TITLE
Request Context Inside Hook Callbacks

### DIFF
--- a/docs/source/crud/hooks.rst
+++ b/docs/source/crud/hooks.rst
@@ -64,7 +64,7 @@ pre_save
 ~~~~~~~~
 
 This hook runs during POST requests, prior to inserting data into the database.
-It takes a single parameter, ``row``, and should return the same:
+It takes a single parameter, ``row``, and should return the row:
 
 .. code-block:: python
 
@@ -130,6 +130,17 @@ It takes one parameter, ``row_id`` which is the id of the row to be deleted.
             Hook(hook_type=HookType.pre_delete, callable=pre_delete)
         ]
     )
+
+Dependency injection
+~~~~~~~~~~~~~~~~~~~~
+
+Each hook can optionally receive the ``Starlette`` request object. Just
+add ``request`` as an argument in your hook, and it'll be injected automatically.
+
+.. code-block:: python
+
+    async def set_movie_rating_10(row: Movie, request: Request):
+        ...
 
 -------------------------------------------------------------------------------
 

--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -810,7 +810,10 @@ class PiccoloCRUD(Router):
             row = self.table(**model.dict())
             if self._hook_map:
                 row = await execute_post_hooks(
-                    hooks=self._hook_map, hook_type=HookType.pre_save, row=row
+                    hooks=self._hook_map,
+                    hook_type=HookType.pre_save,
+                    row=row,
+                    request=request,
                 )
             response = await row.save().run()
             json = dump_json(response)
@@ -1054,6 +1057,7 @@ class PiccoloCRUD(Router):
                 hook_type=HookType.pre_patch,
                 row_id=row_id,
                 values=values,
+                request=request,
             )
 
         try:
@@ -1083,6 +1087,7 @@ class PiccoloCRUD(Router):
                 hooks=self._hook_map,
                 hook_type=HookType.pre_delete,
                 row_id=row_id,
+                request=request,
             )
 
         try:

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -3,6 +3,7 @@ import typing as t
 from enum import Enum
 
 from piccolo.table import Table
+from starlette.requests import Request
 
 
 class HookType(Enum):
@@ -22,13 +23,23 @@ class Hook:
 
 
 async def execute_post_hooks(
-    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row: Table
+    hooks: t.Dict[HookType, t.List[Hook]],
+    hook_type: HookType,
+    row: Table,
+    request: Request,
 ):
     for hook in hooks.get(hook_type, []):
+        signature = inspect.signature(hook.callable)
+        kwargs = dict(row=row)
+        # Include request in hook call arguments if possible
+        if {i for i in signature.parameters.keys()}.intersection(
+            {"kwargs", "request"}
+        ):
+            kwargs.update(request=request)
         if inspect.iscoroutinefunction(hook.callable):
-            row = await hook.callable(row)
+            row = await hook.callable(**kwargs)
         else:
-            row = hook.callable(row)
+            row = hook.callable(**kwargs)
     return row
 
 
@@ -37,20 +48,35 @@ async def execute_patch_hooks(
     hook_type: HookType,
     row_id: t.Any,
     values: t.Dict[t.Any, t.Any],
+    request: Request,
 ) -> t.Dict[t.Any, t.Any]:
     for hook in hooks.get(hook_type, []):
+        signature = inspect.signature(hook.callable)
+        kwargs = dict(row_id=row_id, values=values)
+        # Include request in hook call arguments if possible
+        if {i for i in signature.parameters.keys()}.intersection(
+            {"kwargs", "request"}
+        ):
+            kwargs.update(request=request)
         if inspect.iscoroutinefunction(hook.callable):
-            values = await hook.callable(row_id=row_id, values=values)
+            values = await hook.callable(**kwargs)
         else:
-            values = hook.callable(row_id=row_id, values=values)
+            values = hook.callable(**kwargs)
     return values
 
 
 async def execute_delete_hooks(
-    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any
+    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any, request: Request
 ):
     for hook in hooks.get(hook_type, []):
+        signature = inspect.signature(hook.callable)
+        kwargs = dict(row_id=row_id)
+        # Include request in hook call arguments if possible
+        if {i for i in signature.parameters.keys()}.intersection(
+            {"kwargs", "request"}
+        ):
+            kwargs.update(request=request)
         if inspect.iscoroutinefunction(hook.callable):
-            await hook.callable(row_id=row_id)
+            await hook.callable(**kwargs)
         else:
-            hook.callable(row_id=row_id)
+            hook.callable(**kwargs)

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -30,7 +30,7 @@ async def execute_post_hooks(
 ):
     for hook in hooks.get(hook_type, []):
         signature = inspect.signature(hook.callable)
-        kwargs = dict(row=row)
+        kwargs: t.Dict[str, t.Any] = dict(row=row)
         # Include request in hook call arguments if possible
         if {i for i in signature.parameters.keys()}.intersection(
             {"kwargs", "request"}

--- a/piccolo_api/crud/hooks.py
+++ b/piccolo_api/crud/hooks.py
@@ -66,7 +66,10 @@ async def execute_patch_hooks(
 
 
 async def execute_delete_hooks(
-    hooks: t.Dict[HookType, t.List[Hook]], hook_type: HookType, row_id: t.Any, request: Request
+    hooks: t.Dict[HookType, t.List[Hook]],
+    hook_type: HookType,
+    row_id: t.Any,
+    request: Request,
 ):
     for hook in hooks.get(hook_type, []):
         signature = inspect.signature(hook.callable)

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -63,11 +63,7 @@ async def failing_hook(row_id: int):
     raise Exception("hook failed")
 
 
-def non_coroutine_hook(row: Movie):
-    # TODO: needed for coverage?
-    pass
-
-
+# TODO - add test for a non-async hook.
 class TestPostHooks(TestCase):
     def setUp(self):
         Movie.create_table(if_not_exists=True).run_sync()

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -54,7 +54,7 @@ async def additional_name_details(row: Movie, request: Request):
     return row
 
 
-async def test_raises(row_id: int, request: Request):
+async def raises_exception(row_id: int, request: Request):
     if request.query_params.get("director_name", False):
         raise Exception("Test Passed")
 
@@ -260,7 +260,10 @@ class TestPostHooks(TestCase):
                 table=Movie,
                 read_only=False,
                 hooks=[
-                    Hook(hook_type=HookType.pre_delete, callable=test_raises)
+                    Hook(
+                        hook_type=HookType.pre_delete,
+                        callable=raises_exception,
+                    )
                 ],
             )
         )

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from fastapi import Request
 from piccolo.columns import Integer, Varchar
 from piccolo.columns.readable import Readable
 from piccolo.table import Table
@@ -7,6 +8,10 @@ from starlette.testclient import TestClient
 
 from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.crud.hooks import Hook, HookType
+
+
+class TestRaises(Exception):
+    pass
 
 
 class Movie(Table):
@@ -39,8 +44,30 @@ async def look_up_existing(row_id: int, values: dict):
     return values
 
 
+async def add_additional_name_details(row_id: int, values: dict, request: Request):
+    director = request.query_params.get("director_name", "")
+    values["name"] = values["name"] + f" ({director})"
+    return values
+
+
+async def additional_name_details(row: Movie, request: Request):
+    director = request.query_params.get("director_name", "")
+    row["name"] = f"{row.name} ({director})"
+    return row
+
+
+async def test_raises(row_id: int, request: Request):
+    if request.query_params.get("director_name", False):
+        raise TestRaises("Test Passed")
+
+
 async def failing_hook(row_id: int):
     raise Exception("hook failed")
+
+
+def non_coroutine_hook(row: Movie):
+    # TODO: needed for coverage?
+    pass
 
 
 class TestPostHooks(TestCase):
@@ -49,6 +76,32 @@ class TestPostHooks(TestCase):
 
     def tearDown(self):
         Movie.alter().drop_table().run_sync()
+
+    def test_request_context_passed_to_post_hook(self):
+        """
+        Make sure request context can be passed to post hook
+        callable
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie,
+                read_only=False,
+                hooks=[
+                    Hook(
+                        hook_type=HookType.pre_save,
+                        callable=additional_name_details,
+                    )
+                ],
+            )
+        )
+        json_req = {
+            "name": "Star Wars",
+            "rating": 93,
+            "director_name": "George",
+        }
+        _ = client.post("/", json=json_req, params={"director_name": "George"})
+        movie = Movie.objects().first().run_sync()
+        self.assertEqual(movie.name, "Star Wars (George)")
 
     def test_single_pre_post_hook(self):
         """
@@ -95,6 +148,46 @@ class TestPostHooks(TestCase):
         _ = client.post("/", json=json_req)
         movie = Movie.objects().first().run_sync()
         self.assertEqual(movie.rating, 20)
+
+    def test_request_context_passed_to_patch_hook(self):
+        """
+        Make sure request context can be passed to patch hook
+        callable
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie,
+                read_only=False,
+                hooks=[
+                    Hook(
+                        hook_type=HookType.pre_patch,
+                        callable=add_additional_name_details,
+                    )
+                ],
+            )
+        )
+
+        movie = Movie(name="Star Wars", rating=93)
+        movie.save().run_sync()
+
+        new_name = "Star Wars: A New Hope"
+        new_name_modified = new_name + " (George)"
+
+        json_req = {
+            "name": new_name,
+        }
+
+        response = client.patch(
+            f"/{movie.id}/", json=json_req, params={"director_name": "George"})
+        self.assertTrue(response.status_code == 200)
+
+        # Make sure the row is returned:
+        response_json = response.json()
+        self.assertTrue(response_json["name"] == new_name_modified)
+
+        # Make sure the underlying database row was changed:
+        movies = Movie.select().run_sync()
+        self.assertTrue(movies[0]["name"] == new_name_modified)
 
     def test_pre_patch_hook(self):
         """
@@ -158,6 +251,54 @@ class TestPostHooks(TestCase):
 
         movies = Movie.select().run_sync()
         self.assertTrue(movies[0]["name"] == original_name)
+
+    def test_request_context_passed_to_delete_hook(self):
+        """
+        Make sure request context can be passed to delete hook
+        callable
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie,
+                read_only=False,
+                hooks=[
+                    Hook(
+                        hook_type=HookType.pre_save,
+                        callable=additional_name_details,
+                    )
+                ],
+            )
+        )
+        json_req = {
+            "name": "Star Wars",
+            "rating": 93,
+            "director_name": "George",
+        }
+        _ = client.post("/", json=json_req, params={"director_name": "George"})
+        movie = Movie.objects().first().run_sync()
+        self.assertEqual(movie.name, "Star Wars (George)")
+
+    def test_request_context_passed_to_delete_hook(self):
+        """
+        Make sure request context can be passed to patch hook
+        callable
+        """
+        client = TestClient(
+            PiccoloCRUD(
+                table=Movie,
+                read_only=False,
+                hooks=[
+                    Hook(hook_type=HookType.pre_delete, callable=test_raises)
+                ],
+            )
+        )
+
+        movie = Movie(name="Star Wars", rating=10)
+        movie.save().run_sync()
+
+        with self.assertRaises(TestRaises):
+            _ = client.delete(
+                f"/{movie.id}/", params={"director_name": "George"})
 
     def test_delete_hook_fails(self):
         """


### PR DESCRIPTION
Added implementation for passing request context to hook callbacks. Wrote tests for it. Hope it is suitable.
Addresses [this](https://github.com/piccolo-orm/piccolo_api/discussions/154) discussion.