### PR TITLE
bump minimum fastapi version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -6,4 +6,4 @@ pip-upgrader==1.4.15
 wheel==0.37.1
 
 # Version pin FastAPI, so MyPy is more predictable.
-fastapi==0.58.0
+fastapi==0.65.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ Jinja2>=2.11.0
 piccolo[postgres]>=0.89.0
 pydantic[email]>=1.6
 python-multipart>=0.0.5
-fastapi>=0.58.0
+fastapi>=0.65.2
 PyJWT>=2.0.0
 httpx>=0.20.0


### PR DESCRIPTION
Versions lower than 0.65.2 have a CSRF bug.