### PR TITLE
Added `is_null` and `not_null` operators

### DIFF
--- a/docs/source/crud/piccolo_crud.rst
+++ b/docs/source/crud/piccolo_crud.rst
@@ -127,22 +127,38 @@ Get all movies with 'star wars' in the name:
 Operators
 ~~~~~~~~~
 
-As shown above you can specify which operator to use. The allowed operators are:
+As shown above you can specify which operator to use. For numeric, and date /
+time fields the following operators are allowed:
 
-* lt: Less Than
-* lte: Less Equal Than
-* gt: Greater Than
-* gte: Greater Equal Than
-* e: Equal (default)
+* ``lt``: Less Than
+* ``lte``: Less Than or Equal
+* ``gt``: Greater Than
+* ``gte``: Greater Than or Equal
+* ``e``: Equal (default)
 
 To specify which operator to use, pass a query parameter like ``field__operator=operator_name``.
 For example ``duration__operator=gte``.
 
-A query which fetches all movies lasting more than 200 minutes:
+Here's a query which fetches all movies lasting more than 200 minutes:
 
 .. code-block::
 
     GET /movie/?duration=200&duration__operator=gte
+
+``is_null`` / ``not_null``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All field types also support the ``is_null`` and ``not_null`` operators.
+
+For example:
+
+.. code-block::
+
+    # Get all rows with a null duration
+    GET /movie/duration__operator=is_null
+
+    # Get all rows without a null duration
+    GET /movie/duration__operator=not_null
 
 Match type
 ~~~~~~~~~~

--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -651,28 +651,28 @@ class PiccoloCRUD(Router):
                 values = value if isinstance(value, list) else [value]
 
                 for value in values:
-                    if isinstance(column, (Varchar, Text)):
-                        match_type = params.match_types[field_name]
-                        if match_type == "exact":
-                            clause = column.__eq__(value)
-                        elif match_type == "starts":
-                            clause = column.ilike(f"{value}%")
-                        elif match_type == "ends":
-                            clause = column.ilike(f"%{value}")
-                        else:
-                            clause = column.ilike(f"%{value}%")
-                        query = query.where(clause)
-                    elif isinstance(column, Array):
-                        query = query.where(column.any(value))
-                    else:
-                        operator = params.operators[field_name]
-                        if operator in (IsNull, IsNotNull):
-                            query = query.where(
-                                Where(
-                                    column=column,
-                                    operator=operator,
-                                )
+                    operator = params.operators[field_name]
+                    if operator in (IsNull, IsNotNull):
+                        query = query.where(
+                            Where(
+                                column=column,
+                                operator=operator,
                             )
+                        )
+                    else:
+                        if isinstance(column, (Varchar, Text)):
+                            match_type = params.match_types[field_name]
+                            if match_type == "exact":
+                                clause = column.__eq__(value)
+                            elif match_type == "starts":
+                                clause = column.ilike(f"{value}%")
+                            elif match_type == "ends":
+                                clause = column.ilike(f"%{value}")
+                            else:
+                                clause = column.ilike(f"%{value}%")
+                            query = query.where(clause)
+                        elif isinstance(column, Array):
+                            query = query.where(column.any(value))
                         else:
                             query = query.where(
                                 Where(
@@ -681,6 +681,7 @@ class PiccoloCRUD(Router):
                                     operator=operator,
                                 )
                             )
+
         return query
 
     @apply_validators

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -4,11 +4,12 @@ Enhancing Piccolo integration with FastAPI.
 
 from __future__ import annotations
 
+import datetime
 import typing as t
 from collections import defaultdict
 from decimal import Decimal
 from enum import Enum
-from inspect import Parameter, Signature
+from inspect import Parameter, Signature, isclass
 
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.params import Query
@@ -461,7 +462,9 @@ class FastAPIWrapper:
                     )
                 )
 
-            if type_ is str:
+            # We have to check if it's a subclass of `str` for Varchar, which
+            # uses Pydantics `constr` (constrained string).
+            if type_ is str or (isclass(type_) and issubclass(type_, str)):
                 parameters.append(
                     Parameter(
                         name=f"{field_name}__match",

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -422,7 +422,15 @@ class FastAPIWrapper:
                 ),
             )
 
-            if type_ in (int, float, Decimal):
+            if type_ in (
+                int,
+                float,
+                Decimal,
+                datetime.date,
+                datetime.datetime,
+                datetime.time,
+                datetime.timedelta,
+            ):
                 parameters.append(
                     Parameter(
                         name=f"{field_name}__operator",

--- a/piccolo_api/fastapi/endpoints.py
+++ b/piccolo_api/fastapi/endpoints.py
@@ -432,7 +432,22 @@ class FastAPIWrapper:
                             description=(
                                 f"Which operator to use for `{field_name}`. "
                                 "The options are `e` (equals - default) `lt`, "
-                                "`lte`, `gt`, and `gte`."
+                                "`lte`, `gt`, `gte`, `is_null`, and "
+                                "`not_null`."
+                            ),
+                        ),
+                    )
+                )
+            else:
+                parameters.append(
+                    Parameter(
+                        name=f"{field_name}__operator",
+                        kind=Parameter.POSITIONAL_OR_KEYWORD,
+                        default=Query(
+                            default=None,
+                            description=(
+                                f"Which operator to use for `{field_name}`. "
+                                "The options are `is_null`, and `not_null`."
                             ),
                         ),
                     )

--- a/piccolo_api/session_auth/tables.py
+++ b/piccolo_api/session_auth/tables.py
@@ -83,9 +83,7 @@ class SessionsBase(Table, tablename="sessions"):
             happens. The ``max_expiry_date`` remains the same, so there's a
             hard limit on how long a session can be used for.
         """
-        session: SessionsBase = (
-            await cls.objects().where(cls.token == token).first().run()
-        )
+        session = await cls.objects().where(cls.token == token).first().run()
 
         if not session:
             return None

--- a/piccolo_api/token_auth/middleware.py
+++ b/piccolo_api/token_auth/middleware.py
@@ -65,17 +65,16 @@ class PiccoloTokenAuthProvider(TokenAuthProvider):
             raise AuthenticationError()
 
         user = (
-            await self.auth_table.select(self.auth_table.username)
+            await self.auth_table.objects()
             .where(self.auth_table._meta.primary_key == user_id)
             .first()
             .run()
         )
 
-        if not user:
+        if user is None:
             raise AuthenticationError()
 
-        user = User(user=user)
-        return user
+        return User(user=user)
 
 
 DEFAULT_PROVIDER = PiccoloTokenAuthProvider()

--- a/piccolo_api/token_auth/tables.py
+++ b/piccolo_api/token_auth/tables.py
@@ -9,7 +9,7 @@ from piccolo.table import Table
 from piccolo.utils.sync import run_sync
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from piccolo.query import Select
+    from piccolo.query.methods.select import First
 
 
 def generate_token() -> str:
@@ -56,7 +56,7 @@ class TokenAuth(Table):
         return run_sync(cls.create_token(user_id))
 
     @classmethod
-    async def authenticate(cls, token: str) -> Select:
+    async def authenticate(cls, token: str) -> First:
         return cls.select(cls.user.id).where(cls.token == token).first()
 
     @classmethod

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.11.0
-piccolo[postgres]>=0.89.0
+piccolo[postgres]>=0.104.0
 pydantic[email]>=1.6
 python-multipart>=0.0.5
 fastapi>=0.87.0

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -849,6 +849,17 @@ class TestGetAll(TestCase):
             {"rows": [{"id": 1, "movie": 1, "name": "Luke Skywalker"}]},
         )
 
+        # Make sure the null operator takes precedence
+        response = client.get(
+            "/",
+            params={"movie": 2, "movie__operator": "not_null"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"rows": [{"id": 1, "movie": 1, "name": "Luke Skywalker"}]},
+        )
+
     def test_match(self):
         client = TestClient(PiccoloCRUD(table=Movie, read_only=False))
 

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -803,9 +803,9 @@ class TestGetAll(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"rows": rows})
 
-    def test_operator(self):
+    def test_operator_gt(self):
         """
-        Test filters - greater than.
+        Test operator - greater than.
         """
         client = TestClient(PiccoloCRUD(table=Movie, read_only=False))
         response = client.get(
@@ -816,6 +816,37 @@ class TestGetAll(TestCase):
         self.assertEqual(
             response.json(),
             {"rows": [{"id": 1, "name": "Star Wars", "rating": 93}]},
+        )
+
+    def test_operator_null(self):
+        """
+        Test operators - `is_null` / `not_null`.
+        """
+        # Create a role with a null foreign key value.
+        Role(name="Joe Bloggs").save().run_sync()
+
+        client = TestClient(PiccoloCRUD(table=Role, read_only=False))
+
+        # Null
+        response = client.get(
+            "/",
+            params={"movie__operator": "is_null"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"rows": [{"id": 2, "movie": None, "name": "Joe Bloggs"}]},
+        )
+
+        # Not Null
+        response = client.get(
+            "/",
+            params={"movie__operator": "not_null"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"rows": [{"id": 1, "movie": 1, "name": "Luke Skywalker"}]},
         )
 
     def test_match(self):

--- a/tests/crud/test_hooks.py
+++ b/tests/crud/test_hooks.py
@@ -36,7 +36,8 @@ async def remove_spaces(row_id: int, values: dict):
 
 async def look_up_existing(row_id: int, values: dict):
     row = await Movie.objects().get(Movie._meta.primary_key == row_id).run()
-    values["name"] = row.name
+    if row is not None:
+        values["name"] = row.name
     return values
 
 


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo_api/issues/104

You can now get all rows with a null / not-null value in `PiccoloCRUD`.

For example, if we have a nullable column called `score`:

```
GET /?score__operator=is_null
```

Likewise, to get all rows whose `score` is not null:

```
GET /?score__operator=not_null
```

If we just tried passing in `GET /?score=null` it causes all sorts of issues (for example, API validation would fail, as we're now passing a string instead of a number), which is why we've done it this way.