### PR TITLE
Updating JSON schema responses

### DIFF
--- a/piccolo_api/crud/endpoints.py
+++ b/piccolo_api/crud/endpoints.py
@@ -299,7 +299,7 @@ class PiccoloCRUD(Router):
             self.table,
             model_name=f"{self.table.__name__}In",
             exclude_columns=(self.table._meta.primary_key,),
-            **self.schema_extra,
+            json_schema_extra={"extra": self.schema_extra},
         )
 
     def _pydantic_model_output(

--- a/tests/crud/test_crud_endpoints.py
+++ b/tests/crud/test_crud_endpoints.py
@@ -461,14 +461,18 @@ class TestSchema(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "help_text": None,
-                "primary_key_name": "id",
+                "extra": {
+                    "help_text": None,
+                    "primary_key_name": "id",
+                    "visible_fields_options": ["id", "name", "rating"],
+                },
                 "properties": {
                     "name": {
                         "extra": {
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "maxLength": 100,
                         "title": "Name",
@@ -481,6 +485,7 @@ class TestSchema(TestCase):
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Rating",
                     },
@@ -488,7 +493,6 @@ class TestSchema(TestCase):
                 "required": ["name"],
                 "title": "MovieIn",
                 "type": "object",
-                "visible_fields_options": ["id", "name", "rating"],
             },
         )
 
@@ -515,8 +519,11 @@ class TestSchema(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "help_text": None,
-                "primary_key_name": "id",
+                "extra": {
+                    "help_text": None,
+                    "primary_key_name": "id",
+                    "visible_fields_options": ["id", "score"],
+                },
                 "properties": {
                     "score": {
                         "anyOf": [{"type": "integer"}, {"type": "null"}],
@@ -533,13 +540,13 @@ class TestSchema(TestCase):
                             },
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Score",
                     }
                 },
                 "title": "ReviewIn",
                 "type": "object",
-                "visible_fields_options": ["id", "score"],
             },
         )
 
@@ -558,19 +565,31 @@ class TestSchema(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "help_text": None,
-                "primary_key_name": "id",
+                "extra": {
+                    "help_text": None,
+                    "primary_key_name": "id",
+                    "visible_fields_options": [
+                        "id",
+                        "movie",
+                        "movie.id",
+                        "movie.name",
+                        "movie.rating",
+                        "name",
+                    ],
+                },
                 "properties": {
                     "movie": {
                         "anyOf": [{"type": "integer"}, {"type": "null"}],
                         "default": None,
                         "extra": {
                             "choices": None,
-                            "foreign_key": True,
+                            "foreign_key": {
+                                "target_column": "id",
+                                "to": "movie",
+                            },
                             "help_text": None,
                             "nullable": True,
-                            "target_column": "id",
-                            "to": "movie",
+                            "secret": False,
                         },
                         "title": "Movie",
                     },
@@ -584,20 +603,13 @@ class TestSchema(TestCase):
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Name",
                     },
                 },
                 "title": "RoleIn",
                 "type": "object",
-                "visible_fields_options": [
-                    "id",
-                    "movie",
-                    "movie.id",
-                    "movie.name",
-                    "movie.rating",
-                    "name",
-                ],
             },
         )
 

--- a/tests/fastapi/test_fastapi_endpoints.py
+++ b/tests/fastapi/test_fastapi_endpoints.py
@@ -103,8 +103,11 @@ class TestResponses(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "help_text": None,
-                "primary_key_name": "id",
+                "extra": {
+                    "help_text": None,
+                    "primary_key_name": "id",
+                    "visible_fields_options": ["id", "name", "rating"],
+                },
                 "properties": {
                     "name": {
                         "anyOf": [
@@ -116,6 +119,7 @@ class TestResponses(TestCase):
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Name",
                     },
@@ -126,13 +130,13 @@ class TestResponses(TestCase):
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Rating",
                     },
                 },
                 "title": "MovieIn",
                 "type": "object",
-                "visible_fields_options": ["id", "name", "rating"],
             },
         )
 
@@ -143,19 +147,31 @@ class TestResponses(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "help_text": None,
-                "primary_key_name": "id",
+                "extra": {
+                    "help_text": None,
+                    "primary_key_name": "id",
+                    "visible_fields_options": [
+                        "id",
+                        "movie",
+                        "movie.id",
+                        "movie.name",
+                        "movie.rating",
+                        "name",
+                    ],
+                },
                 "properties": {
                     "movie": {
                         "anyOf": [{"type": "integer"}, {"type": "null"}],
                         "default": None,
                         "extra": {
                             "choices": None,
-                            "foreign_key": True,
+                            "foreign_key": {
+                                "target_column": "id",
+                                "to": "movie",
+                            },
                             "help_text": None,
                             "nullable": True,
-                            "target_column": "id",
-                            "to": "movie",
+                            "secret": False,
                         },
                         "title": "Movie",
                     },
@@ -169,20 +185,13 @@ class TestResponses(TestCase):
                             "choices": None,
                             "help_text": None,
                             "nullable": False,
+                            "secret": False,
                         },
                         "title": "Name",
                     },
                 },
                 "title": "RoleIn",
                 "type": "object",
-                "visible_fields_options": [
-                    "id",
-                    "movie",
-                    "movie.id",
-                    "movie.name",
-                    "movie.rating",
-                    "name",
-                ],
             },
         )
 


### PR DESCRIPTION
Fixing the tests, and using the new `json_schema_extra` argument for `create_pydantic_model`.