### PR TITLE
Fix the CSP regression

### DIFF
--- a/piccolo_api/csp/middleware.py
+++ b/piccolo_api/csp/middleware.py
@@ -29,7 +29,7 @@ class CSPMiddleware:
             if message["type"] == "http.response.start":
                 headers = message.get("headers", [])
                 header_value = bytes(
-                    f"default-src: '{self.config.default_src}'", "utf8"
+                    f"default-src '{self.config.default_src}'", "utf8"
                 )
                 if self.config.report_uri:
                     header_value = (

--- a/tests/csp/test_csp.py
+++ b/tests/csp/test_csp.py
@@ -36,7 +36,7 @@ class TestCSPMiddleware(TestCase):
         # Make sure the headers got added:
         self.assertEqual(
             response.headers["content-security-policy"],
-            "default-src: 'self'",
+            "default-src 'self'",
         )
 
         # Make sure the original headers are still intact:
@@ -53,7 +53,7 @@ class TestCSPMiddleware(TestCase):
 
         self.assertEqual(
             response.headers.get("content-security-policy"),
-            "default-src: 'none'",
+            "default-src 'none'",
         )
 
     def test_report_uri(self):
@@ -66,5 +66,5 @@ class TestCSPMiddleware(TestCase):
 
         self.assertEqual(
             response.headers["content-security-policy"],
-            "default-src: 'self'; report-uri foo.com",
+            "default-src 'self'; report-uri foo.com",
         )


### PR DESCRIPTION
The previous version made a change to the CSP which results in an incorrect CSP policy being set, which leads to it being ignored by browsers.