### PR TITLE
Add BaseUser import from piccolo.apps.user.tables

### DIFF
--- a/docs/source/jwt/examples/example.py
+++ b/docs/source/jwt/examples/example.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from fastapi import FastAPI, Request
-from home.tables import Movie  # An example Table
 from piccolo_admin.endpoints import create_admin
 from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.fastapi.endpoints import FastAPIKwargs, FastAPIWrapper
@@ -9,6 +8,9 @@ from piccolo_api.jwt_auth.endpoints import jwt_login
 from piccolo_api.jwt_auth.middleware import JWTBlacklist, JWTMiddleware
 from piccolo.apps.user.tables import BaseUser
 from starlette.routing import Mount, Route
+
+from home.tables import Movie  # An example Table
+
 
 public_app = FastAPI(
     routes=[
@@ -54,6 +56,7 @@ FastAPIWrapper(
 )
 
 public_app.mount("/private", protected_app)
+
 
 # This is optional if you want to provide a logout endpoint
 # in your application. By adding a token to the token blacklist,

--- a/docs/source/jwt/examples/example.py
+++ b/docs/source/jwt/examples/example.py
@@ -7,6 +7,7 @@ from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.fastapi.endpoints import FastAPIKwargs, FastAPIWrapper
 from piccolo_api.jwt_auth.endpoints import jwt_login
 from piccolo_api.jwt_auth.middleware import JWTBlacklist, JWTMiddleware
+from piccolo.apps.user.tables import BaseUser
 from starlette.routing import Mount, Route
 
 public_app = FastAPI(


### PR DESCRIPTION
Imported BaseUser from piccolo.apps.user.tables for use in authentication and JWT middleware integration. This enables the app to validate users against the default Piccolo user table when protecting routes with JWTMiddleware.